### PR TITLE
Fix issue 101

### DIFF
--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -97,8 +97,6 @@ version (OSX)
 {
     // The bottom of the stack
     extern (C) __gshared void* __osx_stack_end = cast(void*)0xC0000000;
-
-    extern (C) extern (C) void _d_osx_image_init2();
 }
 
 /***********************************
@@ -348,8 +346,6 @@ extern (C) int main(int argc, char** argv)
          * of the main thread's stack, so save the address of that.
          */
         __osx_stack_end = cast(void*)&argv;
-
-        _d_osx_image_init2();
     }
 
     version (FreeBSD) version (D_InlineAsm_X86)
@@ -377,7 +373,7 @@ extern (C) int main(int argc, char** argv)
     version (Windows)
     {
         wchar_t*  wcbuf = GetCommandLineW();
-        size_t    wclen = wcslen(wcbuf);
+        size_t 	  wclen = wcslen(wcbuf);
         int       wargc = 0;
         wchar_t** wargs = CommandLineToArgvW(wcbuf, &wargc);
         assert(wargc == argc);

--- a/src/rt/memory_osx.d
+++ b/src/rt/memory_osx.d
@@ -20,7 +20,6 @@ import src.core.sys.osx.mach.getsect;
 
 extern (C) extern __gshared ModuleInfo*[] _moduleinfo_array;
 extern (C) extern __gshared ubyte[] _deh_eh_array;
-extern (C) extern __gshared ubyte[][2] _tls_data_array;
 
 extern (C) void gc_addRange( void* p, size_t sz );
 extern (C) void gc_removeRange( void* p );
@@ -125,47 +124,3 @@ extern (C) void _d_osx_image_init()
     _dyld_register_func_for_add_image( &onAddImage );
     _dyld_register_func_for_remove_image( &onRemoveImage );
 }
-
-/*********************************
- * The following is done separately because it must be done before Thread gets initialized.
- */
-
-extern (C) void onAddImage2(in mach_header* h, intptr_t slide)
-{
-    //printf("onAddImage2()\n");
-
-    if (auto sect = getSection(h, slide, "__DATA", "__tls_data"))
-    {
-        //printf("  tls_data %p %p\n", &sect[0], &sect[length]);
-        /* BUG: this will fail if there are multiple images with __tls_data
-         * sections. Not set up to handle that.
-         */
-        if (!_tls_data_array[0].ptr)
-            _tls_data_array[0] = sect.ptr[0 .. sect.length];
-    }
-
-    if (auto sect = getSection(h, slide, "__DATA", "__tlscoal_nt"))
-    {
-        //printf("  tlscoal_nt %p %p\n", &sect[0], &sect[length]);
-        /* BUG: this will fail if there are multiple images with __tlscoal_nt
-         * sections. Not set up to handle that.
-         */
-        if (!_tls_data_array[1].ptr)
-            _tls_data_array[1] = sect.ptr[0 .. sect.length];
-    }
-}
-
-
-extern (C) void onRemoveImage2(in mach_header* h, intptr_t slide)
-{
-    //printf("onRemoveImage2()\n");
-}
-
-
-extern (C) void _d_osx_image_init2()
-{
-    //printf("_d_osx_image_init2()\n");
-    _dyld_register_func_for_add_image( &onAddImage2 );
-    _dyld_register_func_for_remove_image( &onRemoveImage2 );
-}
-


### PR DESCRIPTION
Fix [Issue 101](https://github.com/ldc-developers/ldc/issues/101). Now compiles, threads work on OSX Lion 10.7.4, 64-bit, compiled from ldc-developers/ldc:master.

Revert upstream "fix Issue 4854 - Regression(2.047, Mac 10.5 only) writefln Segmentation fault if no globals", which was only intended for DMD/druntime.
As noted in the conflict, some changes have remained in `thread.d`, but ldc-developers/druntime@fe5ba38abff4c6b787f75b776ea9612e1c6780fc makes them inactive in LDC. It might be better to undo both of them completely.

This reverts commit 73cf2c150665cb17d9365a6e3d6cf144d76312d6.

Conflicts:

```
src/core/thread.d : kept Walter's changes but only if OsxManualTls
  maybe should remove those completely as they aren't needed for
  druntime-ldc.
```
