### PR TITLE
Fix llvm_bswap declaration

### DIFF
--- a/src/ldc/intrinsics.di
+++ b/src/ldc/intrinsics.di
@@ -290,7 +290,7 @@ pragma(LDC_intrinsic, "llvm.fmuladd.f#")
 /// useful for performing operations on data that is not in the target's native
 /// byte order.
 
-pragma(LDC_intrinsic, "llvm.bswap.i#.i#")
+pragma(LDC_intrinsic, "llvm.bswap.i#")
     T llvm_bswap(T)(T val);
 
 


### PR DESCRIPTION
It was causing ICE "Intrinsic name not mangled correctly for type arguments!"
