### PR TITLE
Min g wx64compilation

### DIFF
--- a/src/core/math.d
+++ b/src/core/math.d
@@ -138,13 +138,13 @@ version (LDC)
                 asm
                 {
                     naked;
-                    push RCX;                // push exp (8 bytes)
+                    push RCX;                // push exp (8 bytes), passed in ECX
                     fild int ptr [RSP];      // push exp onto FPU stack
-                    fld real ptr [RSP+8];    // push n   onto FPU stack
+                    pop RCX;                 // return stack to initial state
+                    fld real ptr [RDX];      // push n   onto FPU stack, passed in [RDX]
                     fscale;                  // ST(0) = ST(0) * 2^ST(1)
                     fstp ST(1);              // pop stack maintaining top value => function return value
-                    pop RCX;                 // return stack to initial state
-                    ret 12;                  // argument sizes: exp=0 (in RAX), n=12bytes
+                    ret;                     // no arguments passed via stack
                 }
             }
             else

--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -675,6 +675,9 @@ version( MinGW )
     alias __mingw_vsnprintf _vsnprintf;
     alias __mingw_vsnprintf vsnprintf;
 
+    uint _set_output_format(uint format);
+    enum _TWO_DIGIT_EXPONENT = 1;
+
     intptr_t _get_osfhandle(int fd);
     int _open_osfhandle(intptr_t osfhandle, int flags);
 }


### PR DESCRIPTION
Compilation fails with MinGW-x64 for two reasons:
- usage of x86 assembly in /src/core/math.d that is compiled in x64 mode (MinGW)
- undefined reference to _set_output_format in /src/rt/dmain2.d

This pull-request fixes #847.

The changes are only compiled for version(MinGW).
I am not able to run unittests with the current setup :(
I have tried to verify the generated asm output (including the calling code to a function like the x64 bit version of ldexp). The calling convention is quite different from 32bit mode.
