### PR TITLE
MinGW-x64: fix unresolved symbol problems during linking

### DIFF
--- a/src/core/stdc/math.d
+++ b/src/core/stdc/math.d
@@ -113,7 +113,8 @@ version( DigitalMars )
 
 version( LDC )
 {
-    version( Win64 )
+    version( MinGW ) { }
+    else version( Win64 ) 
         version = MSVC_RUNTIME;
 
 }

--- a/src/rt/msvc.c
+++ b/src/rt/msvc.c
@@ -16,7 +16,7 @@
 
 #if _WIN32
 
-#ifdef _MSC_VER
+#if _MSC_VER || __MINGW64__
 
 #include <Windows.h>
 #include <string.h>


### PR DESCRIPTION
LDC was successfully built with MinGW-x64. However, when building a simple test program using ldc2, linker errors pop up: some symbols in libdruntime are not defined.
This PR fixes the problem that MinGW64 was not properly detected in two places in druntime.
(this fixes all link problems, except for a name mangling issue with naked asm functions, for which I have a fix in LDC itself; with that, a "hello world" program builds and executes successfully!)
