### PR TITLE
Experimental MSVCRT 14 (VS 2015) support

### DIFF
--- a/src/core/stdc/stdarg.d
+++ b/src/core/stdc/stdarg.d
@@ -314,10 +314,10 @@ version( LDC )
     alias char* va_list;
 
     pragma(LDC_va_start)
-        void va_start(T)(va_list ap, ref T);
+        void va_start(T)(va_list ap, ref T) @nogc nothrow;
 
     private pragma(LDC_va_arg)
-        T va_arg_intrinsic(T)(va_list ap);
+        T va_arg_intrinsic(T)(va_list ap) @nogc nothrow;
 
     T va_arg(T)(ref va_list ap)
     {
@@ -442,10 +442,10 @@ version( LDC )
     }
 
     pragma(LDC_va_end)
-        void va_end(va_list ap);
+        void va_end(va_list ap) @nogc nothrow;
 
     pragma(LDC_va_copy)
-        void va_copy(out va_list dest, va_list src);
+        void va_copy(out va_list dest, va_list src) @nogc nothrow;
 }
 else version( X86 )
 {

--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -37,6 +37,9 @@ version (FreeBSD)
     import core.stdc.fenv;
 }
 
+// uncomment for MSVCRT >= 14 (VS 2015)
+//version(LDC) { version(Win64) version = LDC_MSVCRT14; }
+
 extern (C) void _STI_monitor_staticctor();
 extern (C) void _STD_monitor_staticdtor();
 extern (C) void _STI_critical_init();
@@ -266,13 +269,22 @@ extern (C) int _d_run_main(int argc, char **argv, MainFunc mainFunc)
 
     version (Win64)
     {
-        auto fp = __iob_func();
-        stdin = &fp[0];
-        stdout = &fp[1];
-        stderr = &fp[2];
+        version (LDC_MSVCRT14) // requires MSVCRT >= 14 (VS 2015)
+        {
+            stdin  = __acrt_iob_func(0);
+            stdout = __acrt_iob_func(1);
+            stderr = __acrt_iob_func(2);
+        }
+        else
+        {
+            auto fp = __iob_func();
+            stdin  = &fp[0];
+            stdout = &fp[1];
+            stderr = &fp[2];
 
-        // ensure that sprintf generates only 2 digit exponent when writing floating point values
-        _set_output_format(_TWO_DIGIT_EXPONENT);
+            // ensure that *printf generates only 2 digit exponent when writing floating point values
+            _set_output_format(_TWO_DIGIT_EXPONENT);
+        }
 
         // enable full precision for reals
         asm


### PR DESCRIPTION
MS mainly focused on stdio.h in their upcoming C runtime. It provides important C99 fixes, see http://blogs.msdn.com/b/vcblog/archive/2014/06/18/crt-features-fixes-and-breaking-changes-in-visual-studio-14-ctp1.aspx. E.g., it fixes https://github.com/ldc-developers/ldc/issues/761 with no additional changes.

Please note that you'll have to uncomment the `version = LDC_MSVCRT14;` lines in `src/core/stdc/stdio.d` and `src/rt/dmain2.d` to enable MSVCRT 14 support.
