### PR TITLE
fmemopen, open_memstream unavail on OSX

### DIFF
--- a/src/core/sys/posix/stdio.d
+++ b/src/core/sys/posix/stdio.d
@@ -195,9 +195,22 @@ int    fileno(FILE*);
 char*  gets(char*);
 int    pclose(FILE*);
 FILE*  popen(in char*, in char*);
-FILE*  fmemopen(in void* buf, in size_t size, in char* mode);
-FILE*  open_memstream(char** ptr, size_t* sizeloc);
-FILE*  open_wmemstream(wchar_t** ptr, size_t* sizeloc);
+
+
+// memstream functions are conforming to POSIX.1-2008.  These functions are
+// not specified in POSIX.1-2001 and are not widely available on other
+// systems.  For now list systems without, but may make more sense to instead
+// specify systems that do have.
+version( OSX ) {}
+else
+    version = HaveMemstream;
+
+version( HaveMemstream )
+{
+    FILE*  fmemopen(in void* buf, in size_t size, in char* mode);
+    FILE*  open_memstream(char** ptr, size_t* sizeloc);
+    FILE*  open_wmemstream(wchar_t** ptr, size_t* sizeloc);
+}
 
 //
 // Thread-Safe Functions (TSF)
@@ -262,6 +275,7 @@ version( Solaris )
     enum P_tmpdir  = "/var/tmp/";
 }
 
+version( HaveMemstream )
 unittest
 { /* fmemopen */
     import core.stdc.string : memcmp;
@@ -275,6 +289,7 @@ unittest
     assert(fclose(f) == 0);
 }
 
+version( HaveMemstream )
 unittest
 { /* Note: open_memstream is only useful for writing */
     import core.stdc.string : memcmp;
@@ -292,6 +307,7 @@ else
     assert(fclose(f) == 0);
 }
 
+version( HaveMemstream )
 unittest
 { /* Note: open_wmemstream is only useful for writing */
     import core.stdc.string : memcmp;


### PR DESCRIPTION
The memstream family of POSIX functions are not available as of MacOSX 10.10 so need to be disabled for version (OSX) to avoid link errors for druntime test-runner.

This change should go upstream too.
