### PR TITLE
Remove private from volatileLoad/Store

### DIFF
--- a/src/core/bitop.d
+++ b/src/core/bitop.d
@@ -462,22 +462,22 @@ version (AnyX86)
 
 version (LDC)
 {
-    private pragma(LDC_intrinsic, "ldc.bitop.vld")
+    pragma(LDC_intrinsic, "ldc.bitop.vld")
         ubyte volatileLoad(ubyte* ptr);
-    private pragma(LDC_intrinsic, "ldc.bitop.vld")
+    pragma(LDC_intrinsic, "ldc.bitop.vld")
         ushort volatileLoad(ushort* ptr);
-    private pragma(LDC_intrinsic, "ldc.bitop.vld")
+    pragma(LDC_intrinsic, "ldc.bitop.vld")
         uint volatileLoad(uint* ptr);
-    private pragma(LDC_intrinsic, "ldc.bitop.vld")
+    pragma(LDC_intrinsic, "ldc.bitop.vld")
         ulong volatileLoad(ulong* ptr);
 
-    private pragma(LDC_intrinsic, "ldc.bitop.vst")
+    pragma(LDC_intrinsic, "ldc.bitop.vst")
         void volatileStore(ubyte* ptr, ubyte value);
-    private pragma(LDC_intrinsic, "ldc.bitop.vst")
+    pragma(LDC_intrinsic, "ldc.bitop.vst")
         void volatileStore(ushort* ptr, ushort value);
-    private pragma(LDC_intrinsic, "ldc.bitop.vst")
+    pragma(LDC_intrinsic, "ldc.bitop.vst")
         void volatileStore(uint* ptr, uint value);
-    private pragma(LDC_intrinsic, "ldc.bitop.vst")
+    pragma(LDC_intrinsic, "ldc.bitop.vst")
         void volatileStore(ulong* ptr, ulong value);
 }
 else


### PR DESCRIPTION
So can be used outside module bitop.

Test

``` D
import core.bitop;

enum pa = cast(ulong*)0x100;
enum pb = cast(uint*)0x110;
enum pc = cast(ushort*)0x120;
enum pd = cast(ubyte*)0x130;

void dovolatile(T)(T* p)
{
    auto x = volatileLoad(p);
    volatileStore(p, x|1);
}

void foo()
{
    dovolatile(pa);
    dovolatile(pb);
    dovolatile(pc);
    dovolatile(pd);
}
```
