### PR TITLE
Fix linking on Windows: libcmt conflicts with default linking with libcmtd

### DIFF
--- a/src/rt/monitor_.d
+++ b/src/rt/monitor_.d
@@ -55,8 +55,8 @@ private
         }
         else version (CRuntime_Microsoft)
         {
-            pragma(lib, "libcmt.lib");
-            pragma(lib, "oldnames.lib");
+            // pragma(lib, "libcmt.lib");
+            // pragma(lib, "oldnames.lib");
         }
         import core.sys.windows.windows;
 


### PR DESCRIPTION
No explicit mention of those libs is necessary for LDC.
libcmt.lib conflicts with libcmtd.lib (linked to by default) and so linking fails without this PR.
