### PR TITLE
[2.067] MSVCRT 14 (VS 2015) support

### DIFF
--- a/src/core/stdc/stdarg.d
+++ b/src/core/stdc/stdarg.d
@@ -314,10 +314,10 @@ version( LDC )
     alias char* va_list;
 
     pragma(LDC_va_start)
-        void va_start(T)(va_list ap, ref T);
+        void va_start(T)(va_list ap, ref T) @nogc nothrow;
 
     private pragma(LDC_va_arg)
-        T va_arg_intrinsic(T)(va_list ap);
+        T va_arg_intrinsic(T)(va_list ap) @nogc nothrow;
 
     T va_arg(T)(ref va_list ap)
     {
@@ -486,10 +486,10 @@ version( LDC )
     }
 
     pragma(LDC_va_end)
-        void va_end(va_list ap);
+        void va_end(va_list ap) @nogc nothrow;
 
     pragma(LDC_va_copy)
-        void va_copy(out va_list dest, va_list src);
+        void va_copy(out va_list dest, va_list src) @nogc nothrow;
 }
 else version( X86 )
 {

--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -32,8 +32,8 @@ private
   }
 }
 
-// uncomment for MSVCRT >= 14 (VS 2015)
-//version(LDC) { version(Win64) version = LDC_MSVCRT14; }
+// comment the following line for MSVCRT < 14 (Visual Studio 2013 and older)
+version(LDC) { version(Win64) version = LDC_MSVCRT14; }
 
 extern (C):
 @system:

--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -32,6 +32,9 @@ private
   }
 }
 
+// uncomment for MSVCRT >= 14 (VS 2015)
+//version(LDC) { version(Win64) version = LDC_MSVCRT14; }
+
 extern (C):
 @system:
 nothrow:
@@ -77,19 +80,30 @@ else version( CRuntime_Microsoft )
         ///
         FILENAME_MAX = 260,
         ///
-        TMP_MAX      = 32767,
-        ///
         _SYS_OPEN    = 20,      // non-standard
     }
 
     ///
     enum int     _NFILE     = 512;       // non-standard
+
+  version( LDC_MSVCRT14 ) // requires MSVCRT >= 14 (VS 2015)
+  {
+    ///
+    enum int     TMP_MAX    = int.max;
+    ///
+    enum int     L_tmpnam   = 260;
+  }
+  else
+  {
+    ///
+    enum int     TMP_MAX    = short.max;
     ///
     enum string  _P_tmpdir  = "\\"; // non-standard
     ///
     enum wstring _wP_tmpdir = "\\"; // non-standard
     ///
     enum int     L_tmpnam   = _P_tmpdir.length + 12;
+  }
 }
 else version( linux )
 {
@@ -259,8 +273,18 @@ version( CRuntime_DigitalMars )
 else version( CRuntime_Microsoft )
 {
     ///
-    alias int fpos_t; //check this
+    alias long fpos_t;
 
+  version( LDC_MSVCRT14 ) // requires MSVCRT >= 14 (VS 2015)
+  {
+    ///
+    struct _iobuf
+    {
+        void* _Placeholder;
+    }
+  }
+  else
+  {
     ///
     struct _iobuf
     {
@@ -273,6 +297,7 @@ else version( CRuntime_Microsoft )
         int   _bufsiz;
         char* _tmpfname;
     }
+  }
 
     ///
     alias shared(_iobuf) FILE;
@@ -549,38 +574,53 @@ else version( CRuntime_Microsoft )
         _IOLBF   = 0x40,
         ///
         _IONBF   = 4,
-        ///
-        _IOREAD  = 1,     // non-standard
-        ///
-        _IOWRT   = 2,     // non-standard
-        ///
-        _IOMYBUF = 8,     // non-standard
-        ///
-        _IOEOF   = 0x10,  // non-standard
-        ///
-        _IOERR   = 0x20,  // non-standard
-        ///
-        _IOSTRG  = 0x40,  // non-standard
-        ///
-        _IORW    = 0x80,  // non-standard
-        ///
-        _IOAPP   = 0x200, // non-standard
-        ///
-        _IOAPPEND = 0x200, // non-standard
     }
 
     extern shared void function() _fcloseallp;
 
-    private extern shared FILE[_NFILE] _iob;
+    version( LDC_MSVCRT14 ) // requires MSVCRT >= 14 (VS 2015)
+    {
+        shared(FILE)* __acrt_iob_func(uint);
+        ///
+        shared FILE* stdin;  // = __acrt_iob_func(0);
+        ///
+        shared FILE* stdout; // = __acrt_iob_func(1);
+        ///
+        shared FILE* stderr; // = __acrt_iob_func(2);
+    }
+    else
+    {
+      enum
+      {
+        ///
+        _IOREAD   = 1,     // non-standard
+        ///
+        _IOWRT    = 2,     // non-standard
+        ///
+        _IOMYBUF  = 8,     // non-standard
+        ///
+        _IOEOF    = 0x10,  // non-standard
+        ///
+        _IOERR    = 0x20,  // non-standard
+        ///
+        _IOSTRG   = 0x40,  // non-standard
+        ///
+        _IORW     = 0x80,  // non-standard
+        ///
+        _IOAPP    = 0x200, // non-standard
+        ///
+        _IOAPPEND = 0x200, // non-standard
+      }
 
-    shared(FILE)* __iob_func();
+        shared(FILE)* __iob_func();
 
-    ///
-    shared FILE* stdin;  // = &__iob_func()[0];
-    ///
-    shared FILE* stdout; // = &__iob_func()[1];
-    ///
-    shared FILE* stderr; // = &__iob_func()[2];
+        ///
+        shared FILE* stdin;  // = &__iob_func()[0];
+        ///
+        shared FILE* stdout; // = &__iob_func()[1];
+        ///
+        shared FILE* stderr; // = &__iob_func()[2];
+    }
 }
 else version( linux )
 {
@@ -802,6 +842,15 @@ version (MinGW)
 }
 else
 {
+    version (LDC_MSVCRT14)
+    {
+        // MS define the *printf and *scanf function families inline
+        // starting with VS 2015 and its breaking changes.
+        // Link against a lib provided by MS containing appropriate
+        // implementations.
+        pragma(lib, "legacy_stdio_definitions.lib");
+    }
+
     ///
     int fprintf(FILE* stream, in char* format, ...);
     ///
@@ -941,21 +990,46 @@ else version( CRuntime_DigitalMars )
 }
 else version( CRuntime_Microsoft )
 {
-  // No unsafe pointer manipulation.
-  extern (D) @trusted
+  version( LDC_MSVCRT14 ) // requires MSVCRT >= 14 (VS 2015)
   {
-      ///
-    void rewind(FILE* stream)   { fseek(stream,0L,SEEK_SET); stream._flag = stream._flag & ~_IOERR; }
+    // No unsafe pointer manipulation.
+    @trusted
+    {
+        ///
+             void rewind(FILE* stream);
+        ///
+        pure void clearerr(FILE* stream);
+        ///
+        pure int  feof(FILE* stream);
+        ///
+        pure int  ferror(FILE* stream);
+        ///
+        pure int  fileno(FILE* stream);
+    }
+
     ///
-    pure void clearerr(FILE* stream) { stream._flag = stream._flag & ~(_IOERR|_IOEOF);                 }
+    int vsnprintf(char* s, size_t n, in char* format, va_list args);
     ///
-    pure int  feof(FILE* stream)     { return stream._flag&_IOEOF;                       }
-    ///
-    pure int  ferror(FILE* stream)   { return stream._flag&_IOERR;                       }
-    ///
-    pure int  fileno(FILE* stream)   { return stream._file;                              }
+    int snprintf(char* s, size_t n, in char* format, ...);
   }
-  ///
+  else
+  {
+    // No unsafe pointer manipulation.
+    extern (D) @trusted
+    {
+        ///
+             void rewind(FILE* stream)   { fseek(stream, 0L, SEEK_SET); stream._flag = stream._flag & ~_IOERR; }
+        ///
+        pure void clearerr(FILE* stream) { stream._flag = stream._flag & ~(_IOERR | _IOEOF); }
+        ///
+        pure int  feof(FILE* stream)     { return stream._flag & _IOEOF; }
+        ///
+        pure int  ferror(FILE* stream)   { return stream._flag & _IOERR; }
+        ///
+        pure int  fileno(FILE* stream)   { return stream._file; }
+    }
+
+    ///
     int   _snprintf(char* s, size_t n, in char* fmt, ...);
     ///
     alias _snprintf snprintf;
@@ -1002,6 +1076,7 @@ else version( CRuntime_Microsoft )
         else
             return _filbuf(fp);
     }
+  }
 
     ///
     int _lock_file(FILE *fp);

--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -270,13 +270,22 @@ extern (C) int _d_run_main(int argc, char **argv, MainFunc mainFunc)
     }
     version (CRuntime_Microsoft)
     {
-        auto fp = __iob_func();
-        stdin = &fp[0];
-        stdout = &fp[1];
-        stderr = &fp[2];
+        static if (__traits(compiles, __acrt_iob_func(0))) // requires MSVCRT >= 14 (VS 2015)
+        {
+            stdin  = __acrt_iob_func(0);
+            stdout = __acrt_iob_func(1);
+            stderr = __acrt_iob_func(2);
+        }
+        else
+        {
+            auto fp = __iob_func();
+            stdin  = &fp[0];
+            stdout = &fp[1];
+            stderr = &fp[2];
 
-        // ensure that sprintf generates only 2 digit exponent when writing floating point values
-        _set_output_format(_TWO_DIGIT_EXPONENT);
+            // ensure that *printf generates only 2 digit exponent when writing floating point values
+            _set_output_format(_TWO_DIGIT_EXPONENT);
+        }
 
         // enable full precision for reals
         version(Win64)


### PR DESCRIPTION
MS mainly focused on `stdio.h` in their upcoming C runtime. It provides important C99 fixes, see http://blogs.msdn.com/b/vcblog/archive/2014/06/18/crt-features-fixes-and-breaking-changes-in-visual-studio-14-ctp1.aspx. E.g., it fixes https://github.com/ldc-developers/ldc/issues/761 with no additional changes.
