### PR TITLE
Fix usage of RMW-intrinsics in core.atomic.atomicOp()

### DIFF
--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -201,15 +201,30 @@ else version( LDC )
                    op == "^=" || op == "<<=" || op == ">>=" || op == ">>>=" ) // skip "~="
         {
             static if( op == "+=" && __traits(isIntegral, T) && __traits(isIntegral, V1) )
-                return llvm_atomic_rmw_add(&val, mod) + mod;
+            {
+                T m = cast(T) mod;
+                return cast(T)(llvm_atomic_rmw_add(&val, m) + m);
+            }
             else static if( op == "-=" && __traits(isIntegral, T) && __traits(isIntegral, V1) )
-                return llvm_atomic_rmw_sub(&val, mod) - mod;
+            {
+                T m = cast(T) mod;
+                return cast(T)(llvm_atomic_rmw_sub(&val, m) - m);
+            }
             else static if( op == "&=" && __traits(isIntegral, T) && __traits(isIntegral, V1) )
-                return llvm_atomic_rmw_and(&val, mod) & mod;
+            {
+                T m = cast(T) mod;
+                return cast(T)(llvm_atomic_rmw_and(&val, m) & m);
+            }
             else static if( op == "|=" && __traits(isIntegral, T) && __traits(isIntegral, V1) )
-                return llvm_atomic_rmw_or(&val, mod) | mod;
+            {
+                T m = cast(T) mod;
+                return cast(T)(llvm_atomic_rmw_or(&val, m) | m);
+            }
             else static if( op == "^=" && __traits(isIntegral, T) && __traits(isIntegral, V1) )
-                return llvm_atomic_rmw_xor(&val, mod) ^ mod;
+            {
+                T m = cast(T) mod;
+                return cast(T)(llvm_atomic_rmw_xor(&val, m) ^ m);
+            }
             else
             {
                 HeadUnshared!(T) get, set;

--- a/src/ldc/intrinsics.di
+++ b/src/ldc/intrinsics.di
@@ -315,6 +315,8 @@ enum AtomicOrdering {
 };
 alias AtomicOrdering.SequentiallyConsistent DefaultOrdering;
 
+enum AtomicRmwSizeLimit = size_t.sizeof;
+
 /// Used to introduce happens-before edges between operations.
 pragma(LDC_fence)
     void llvm_memory_fence(AtomicOrdering ordering = DefaultOrdering);


### PR DESCRIPTION
The operand needs to be cast to the type T in memory.

When repeating the operation for the atomicOp() return value, which is inconveniently defined as the final result (presumably because atomicOp() is used for both binary operators **and** binary assignment operators), I'm not sure whether we really get the same result.
The LLVM intrinsic will presumably compute the operation using type T directly, while D e.g. refuses to add 2 ubytes (it casts both operands to int before adding). This also means that we need to cast the 2nd operation's result to T, although both operands are of type T. I'm no numeric expert, so I'm not sure whether `oldValue <op> m` and `cast(T)(cast(int)oldValue <op> cast(int)m)` for types T < 32-bit are guaranteed to be equivalent.
