### PR TITLE
AArch64 Add Fiber support and fix GC scanning

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -38,12 +38,6 @@ version( Solaris )
     import core.sys.solaris.sys.types;
 }
 
-version( Solaris )
-{
-    import core.sys.solaris.sys.priocntl;
-    import core.sys.solaris.sys.types;
-}
-
 // this should be true for most architectures
 version = StackGrowsDown;
 
@@ -2465,23 +2459,17 @@ else
             {
                 import ldc.llvmasm;
 
-                // Callee-save registers, according to AAPCS64, section 5.1.1.
-                // FIXME: As loads/stores are explicit on ARM, the code generated for
-                // this is horrible. Better write the entire function in ASM.
+                // Callee-save registers, x19-x28 according to AAPCS64, section
+                // 5.1.1.  Include x29 fp because it optionally can be a callee
+                // saved reg
                 size_t[11] regs = void;
-                __asm("str x19, $0", "=*m", regs.ptr + 0);
-                __asm("str x20, $0", "=*m", regs.ptr + 1);
-                __asm("str x21, $0", "=*m", regs.ptr + 2);
-                __asm("str x22, $0", "=*m", regs.ptr + 3);
-                __asm("str x23, $0", "=*m", regs.ptr + 4);
-                __asm("str x24, $0", "=*m", regs.ptr + 5);
-                __asm("str x25, $0", "=*m", regs.ptr + 6);
-                __asm("str x26, $0", "=*m", regs.ptr + 7);
-                __asm("str x27, $0", "=*m", regs.ptr + 8);
-                __asm("str x28, $0", "=*m", regs.ptr + 9);
+                __asm("stp x19, x20, $0", "=*m", regs.ptr + 0);
+                __asm("stp x21, x22, $0", "=*m", regs.ptr + 2);
+                __asm("stp x23, x24, $0", "=*m", regs.ptr + 4);
+                __asm("stp x25, x26, $0", "=*m", regs.ptr + 6);
+                __asm("stp x27, x28, $0", "=*m", regs.ptr + 8);
                 __asm("str x29, $0", "=*m", regs.ptr + 10);
-
-                __asm("str x31, $0", "=*m", &sp);
+                sp = __asm!(void*)("mov $0, sp", "=r");
             }
             else version (ARM)
             {
@@ -3605,6 +3593,15 @@ private
         {
             version = AsmMIPS_O32_Posix;
             version = AsmExternal;
+        }
+    }
+    else version( AArch64 )
+    {
+        version( Posix )
+        {
+            version = AsmAArch64_Posix;
+            version = AsmExternal;
+            version = AlignFiberStackTo16Byte;
         }
     }
     else version( ARM )
@@ -5131,6 +5128,29 @@ private:
             (cast(ubyte*)pstack - SZ)[0 .. SZ] = 0;
             pstack -= ABOVE;
             *cast(size_t*)(pstack - SZ_RA) = cast(size_t)&fiber_entryPoint;
+        }
+        else version( AsmAArch64_Posix )
+        {
+            // Like others, FP registers and return address (lr) are kept
+            // below the saved stack top (tstack) to hide from GC scanning.
+            // fiber_switchContext expects newp sp to look like this:
+            //   19: x19
+            //   ...
+            //    9: x29 (fp)  <-- newp tstack
+            //    8: x30 (lr)  [&fiber_entryPoint]
+            //    7: d8
+            //   ...
+            //    0: d15
+
+            version( StackGrowsDown ) {}
+            else
+                static assert(false, "Only full descending stacks supported on AArch64");
+
+            // Only need to set return address (lr).  Everything else is fine
+            // zero initialized.
+            pstack -= size_t.sizeof * 11;    // skip past x19-x29
+            push(cast(size_t) &fiber_entryPoint);
+            pstack += size_t.sizeof;         // adjust sp (newp) above lr
         }
         else version( AsmARM_Posix )
         {

--- a/src/core/threadasm.S
+++ b/src/core/threadasm.S
@@ -24,6 +24,15 @@
 .section .note.GNU-stack,"",%progbits
 #endif
 
+/* Let preprocessor tell us if C symbols have a prefix: __USER_LABEL_PREFIX__ */
+#ifdef __USER_LABEL_PREFIX__
+#define GLUE2(a, b) a ## b
+#define GLUE(a, b) GLUE2(a, b)
+#define CSYM(name) GLUE(__USER_LABEL_PREFIX__, name)
+#else
+#define CSYM(name) name
+#endif
+
 /************************************************************************************
  * POWER PC ASM BITS
  ************************************************************************************/
@@ -591,4 +600,59 @@ fiber_switchContext:
     // return by writing lr into pc
     mov pc, r1
     .fnend
+
+#elif defined(__aarch64__)
+/************************************************************************************
+ * AArch64 (arm64) ASM BITS
+ ************************************************************************************/
+/**
+ * preserve/restore AAPCS64 registers
+ *   x19-x28 5.1.1 64-bit callee saved
+ *   x29 fp, or possibly callee saved reg - depends on platform choice 5.2.3)
+ *   x30 lr
+ *   d8-d15  5.1.2 says callee only must save bottom 64-bits (the "d" regs)
+ *
+ * saved regs on stack will look like:
+ *   19: x19
+ *   18: x20
+ *   ...
+ *   10: x28
+ *    9: x29 (fp)  <-- oldp / *newp save stack top
+ *    8: x30 (lr)
+ *    7: d8
+ *   ...
+ *    0: d15       <-- sp
+ */
+        .text
+        .global CSYM(fiber_switchContext)
+        .p2align  2
+CSYM(fiber_switchContext):
+        stp     d15, d14, [sp, #-20*8]!
+        stp     d13, d12, [sp, #2*8]
+        stp     d11, d10, [sp, #4*8]
+        stp     d9, d8,   [sp, #6*8]
+        stp     x30, x29, [sp, #8*8] // lr, fp
+        stp     x28, x27, [sp, #10*8]
+        stp     x26, x25, [sp, #12*8]
+        stp     x24, x23, [sp, #14*8]
+        stp     x22, x21, [sp, #16*8]
+        stp     x20, x19, [sp, #18*8]
+
+        // oldp is set above saved lr (x30) to hide it and float regs
+        // from GC
+        add     x19, sp, #9*8
+        str     x19, [x0]       // *oldp tstack
+        sub     sp, x1, #9*8    // switch to newp sp
+
+        ldp     x20, x19, [sp, #18*8]
+        ldp     x22, x21, [sp, #16*8]
+        ldp     x24, x23, [sp, #14*8]
+        ldp     x26, x25, [sp, #12*8]
+        ldp     x28, x27, [sp, #10*8]
+        ldp     x30, x29, [sp, #8*8] // lr, fp
+        ldp     d9, d8,   [sp, #6*8]
+        ldp     d11, d10, [sp, #4*8]
+        ldp     d13, d12, [sp, #2*8]
+        ldp     d15, d14, [sp], #20*8
+        ret
 #endif


### PR DESCRIPTION
Add AArch64 Fiber support.  Fix register save code for GC scanning.

@redstar - are you able to test these with your setup?  My testing is limited to iPhone 6.
