### PR TITLE
add _d_eh_enter_catch to support exception chaining

### DIFF
--- a/src/ldc/eh/win32.d
+++ b/src/ldc/eh/win32.d
@@ -10,7 +10,7 @@ version(Win32):
 import ldc.eh.common;
 import core.sys.windows.windows;
 import core.exception : onOutOfMemoryError, OutOfMemoryError;
-import core.stdc.stdlib : malloc;
+import core.stdc.stdlib : malloc, free;
 import core.stdc.string : memcpy;
 
 // pointers are image relative for Win64 versions
@@ -86,13 +86,22 @@ enum EXCEPTION_UNWINDING          = 0x02;
 
 enum EH_MAGIC_NUMBER1             = 0x19930520;
 
-extern(C) void _d_throw_exception(Object e)
+extern(C) void _d_throw_exception(Throwable e)
 {
     if (e is null)
         fatalerror("Cannot throw null exception");
     auto ti = typeid(e);
     if (ti is null)
         fatalerror("Cannot throw corrupt exception object with null classinfo");
+
+    if (exceptionStack.length > 0)
+    {
+        // we expect that the terminate handler will be called, so hook
+        // it to avoid it actually terminating
+        if (!old_terminate_handler)
+            old_terminate_handler = set_terminate(&msvc_eh_terminate);
+    }
+    exceptionStack.push(e);
 
     ULONG_PTR[3] ExceptionInformation;
     ExceptionInformation[0] = EH_MAGIC_NUMBER1;
@@ -101,6 +110,8 @@ extern(C) void _d_throw_exception(Object e)
 
     RaiseException(STATUS_MSC_EXCEPTION, EXCEPTION_NONCONTINUABLE, 3, ExceptionInformation.ptr);
 }
+
+///////////////////////////////////////////////////////////////
 
 import rt.util.container.hashtab;
 import core.sync.mutex;
@@ -161,6 +172,142 @@ CatchableType* getCatchableType(TypeInfo_Class ti)
     return ti in catchableHashtab;
 }
 
+///////////////////////////////////////////////////////////////
+extern(C) void _d_eh_enter_catch(Throwable* pe)
+{
+    if (!pe)
+        return; // null for "catch all" in scope(failure), will rethrow
+    Throwable e = *pe;
+
+    while(exceptionStack.length > 0)
+    {
+        Throwable t = exceptionStack.pop();
+        if (t is e)
+            break;
+
+        auto err = cast(Error) t;
+        if (err && !cast(Error)e)
+        {
+            // there is an Error in flight, but we caught an Exception
+            // so we convert it and rethrow the Error
+            err.bypassedException = e;
+            throw err;
+        }
+        t.next = e.next;
+        e.next = t;
+    }
+}
+
+alias terminate_handler = void function();
+
+extern(C) int __uncaught_exceptions();
+extern(C) int __vcrt_getptd();
+extern(C) terminate_handler set_terminate(terminate_handler new_handler);
+
+terminate_handler old_terminate_handler; // explicitely per thread
+
+ExceptionStack exceptionStack;
+
+struct ExceptionStack
+{
+nothrow:
+    ~this()
+    {
+        if (_p)
+            free(_p);
+    }
+
+    void push(Throwable e)
+    {
+        if (_length == _cap)
+            grow();
+        _p[_length++] = e;
+    }
+
+    Throwable pop()
+    {
+        return _p[--_length];
+    }
+
+    ref inout(Throwable) opIndex(size_t idx) inout
+    {
+        return _p[idx];
+    }
+
+    @property size_t length() const { return _length; }
+    @property bool empty() const { return !length; }
+
+private:
+    void grow()
+    {
+        // alloc from GC? add array as a GC range?
+        immutable ncap = _cap ? 2 * _cap : 64;
+        auto p = cast(Throwable*)malloc(ncap * Throwable.sizeof);
+        if (p is null)
+            onOutOfMemoryError();
+        p[0 .. _length] = _p[0 .. _length];
+        free(_p);
+        _p = p;
+        _cap = ncap;
+    }
+
+    size_t _length;
+    Throwable* _p;
+    size_t _cap;
+}
+
+// helper to access TLS from naked asm
+int tlsUncaughtExceptions() nothrow
+{
+    return exceptionStack.length;
+}
+
+auto tlsOldTerminateHandler() nothrow
+{
+    return old_terminate_handler;
+}
+
+void msvc_eh_terminate() nothrow
+{
+    asm nothrow {
+        naked;
+        call tlsUncaughtExceptions;
+        cmp EAX, 0;
+        je L_term;
+
+        // hacking into the call chain to return EXCEPTION_EXECUTE_HANDLER
+        //  as the return value of __FrameUnwindFilter so that
+        // __FrameUnwindToState continues with the next unwind block
+
+        // restore ptd->__ProcessingThrow
+        push EAX;
+        call __vcrt_getptd;
+        pop [EAX+0x18];
+
+        // undo one level of exception frames from terminate()
+        mov EAX,FS:[0];
+        mov EAX,[EAX];
+        mov FS:[0], EAX;
+
+        // assume standard stack frames for callers
+        mov EAX,EBP;   // frame pointer of terminate()
+        mov EAX,[EAX]; // frame pointer of __FrameUnwindFilter
+        mov ESP,EAX;   // restore stack
+        pop EBP;       // and frame pointer
+        mov EAX, 1;    // return EXCEPTION_EXECUTE_HANDLER
+        ret;
+
+    L_term:
+        call tlsOldTerminateHandler;
+        cmp EAX, 0;
+        je L_ret;
+        jmp EAX;
+    L_ret:
+        ret;
+    }
+}
+
+///////////////////////////////////////////////////////////////
 void msvc_eh_init()
 {
     throwInfoMutex = new Mutex;


### PR DESCRIPTION
This is slightly hacky support for exception chaining for C++ EH for MSVC/win32. It hooks the terminate handler to avoid termination when throwing during cleanup.
