### PR TITLE
add missing "else" to disable pragma(lib,"libcmt")

### DIFF
--- a/src/rt/monitor_.d
+++ b/src/rt/monitor_.d
@@ -157,7 +157,7 @@ version (Windows)
         // mention of libcmt (non-debug) conflicts with the implicit
         // libcmtd (debug) link.
     }
-    version (CRuntime_DigitalMars)
+    else version (CRuntime_DigitalMars)
     {
         pragma(lib, "snn.lib");
     }


### PR DESCRIPTION
the version(LDC) makes no sense otherwise...
