### PR TITLE
Ignore real pad in core.internal.convert unittest

### DIFF
--- a/src/core/internal/convert.d
+++ b/src/core/internal/convert.d
@@ -325,7 +325,10 @@ version(unittest)
 
         enum ctbytes = toUbyte2(ctval);
 
-        assert(rtbytes[] == ctbytes);
+        // don't test pad bytes because can be anything
+        enum testsize =
+            (FloatTraits!TYPE.EXPONENT + FloatTraits!TYPE.MANTISSA + 1)/8;
+        assert(rtbytes[0..testsize] == ctbytes[0..testsize]);
     }
 
     private void testConvert()


### PR DESCRIPTION
Change unittest to ignore any pad bytes in a floating point type because
those bits are undefined. This allows core.internal.convert unittest to be enabled. See ldc-developers/ldc#788.

(cherry picked from upstream commit fda62efe0f526e8272dfcc47a4cc7c68f5419569)
