### PR TITLE
Win32: add _d_enter_cleanup/_d_leave_cleanup hooks

### DIFF
--- a/src/ldc/eh/win32.d
+++ b/src/ldc/eh/win32.d
@@ -312,6 +312,22 @@ void msvc_eh_terminate() nothrow
 }
 
 ///////////////////////////////////////////////////////////////
+extern(C) bool _d_enter_cleanup(void* ptr)
+{
+    // currently just used to avoid that a cleanup handler that can
+    // be inferred to not return, is removed by the LLVM optimizer
+    //
+    // TODO: setup an exception handler here (ptr passes the address
+    // of a 16 byte stack area in a parent fuction scope) to deal with
+    // unhandled exceptions during unwinding.
+    return true;
+}
+
+extern(C) void _d_leave_cleanup(void* ptr)
+{
+}
+
+///////////////////////////////////////////////////////////////
 void msvc_eh_init()
 {
     throwInfoMutex = new Mutex;


### PR DESCRIPTION
Required by https://github.com/ldc-developers/ldc/pull/1168

The callback is currently only used to not let the LLVM optimizer remove cleanup code that throws.

Later, it can be used to deal with exceptions during unwinding. This should make it possible to remove the current hacks in this file.
