### PR TITLE
Workaround for issue ldc-developers/ldc#1252

### DIFF
--- a/src/rt/sections_ldc.d
+++ b/src/rt/sections_ldc.d
@@ -407,7 +407,10 @@ private
     version (OSX)
     {
         extern(C) void _d_dyld_getTLSRange(void*, void**, size_t*);
-        private ubyte dummyTlsSymbol;
+        private align(16) ubyte dummyTlsSymbol = 42;
+        // By initalizing dummyTlsSymbol with something non-zero and aligning
+        // to 16-bytes, section __thread_data will be aligned as a workaround
+        // for https://github.com/ldc-developers/ldc/issues/1252
     }
     else version (Windows)
     {


### PR DESCRIPTION
Align and initialize dummyTlsSymbol to force __thread_data section alignment to 16-bytes.  This is needed to obey __thread_bss section alignments.

See issue ldc-developers/ldc#1252 for details.
