### PR TITLE
MSVC/x86 exception handling: rewrite avoiding VC runtime internals

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -3905,6 +3905,10 @@ version( LDC )
         version( X86 ) version = CheckFiberMigration;
         version( X86_64 ) version = CheckFiberMigration;
     }
+    else version( Windows )
+    {
+        version( X86 ) version = CheckFiberMigration;
+    }
 }
 
 // Fiber support for SjLj style exceptions

--- a/src/ldc/attributes.d
+++ b/src/ldc/attributes.d
@@ -57,3 +57,21 @@ struct section {
 struct target {
     string specifier;
 }
+
+/**
+ * When applied to a function and building for Win32, creates a SAFESEH
+ * entry in the binary, so that the function is considered safe to be called
+ * as an exception handler.
+ *
+ * Examples:
+ * ---
+ * import ldc.attributes;
+ *
+ * @safeseh() extern(C) int myExceptionHandler(void*, void*, void*, void*)
+ * {
+ *     return ExceptionContinueSearch;
+ * }
+ * ---
+ */
+struct safeseh {
+};

--- a/src/ldc/eh/common.d
+++ b/src/ldc/eh/common.d
@@ -36,6 +36,9 @@ extern(C) void fatalerror(in char* format, ...)
     abort();
 }
 
+version(Win32) {} else version = notMSVC;
+version(notMSVC):
+
 // ------------------------
 //    Reading DWARF data
 // ------------------------


### PR DESCRIPTION
- setup exception handler for exceptions during cleanup to avoid C++ calling std::terminate
- remove vcruntime hacks
- when converting exception to error, do not rethrow if the catch handles errors, too
- add support for the "safeseh" attribute
