### PR TITLE
Android tweaks

### DIFF
--- a/src/ldc/arm_unwind.c
+++ b/src/ldc/arm_unwind.c
@@ -14,6 +14,9 @@
 
 #include <unwind.h>
 
+// clang's unwind.h doesn't have this
+typedef struct _Unwind_Context _Unwind_Context;
+
 _Unwind_Word _d_eh_GetIP(_Unwind_Context *context)
 {
     return _Unwind_GetIP(context);

--- a/src/rt/sections_android.d
+++ b/src/rt/sections_android.d
@@ -42,7 +42,7 @@ struct SectionGroup
         return _moduleGroup;
     }
 
-    @property immutable(FuncTable)[] ehTables() const
+    version(DigitalMars) @property immutable(FuncTable)[] ehTables() const
     {
         auto pbeg = cast(immutable(FuncTable)*)&_deh_beg;
         auto pend = cast(immutable(FuncTable)*)&_deh_end;


### PR DESCRIPTION
Since [Dan found the same problem with the ARM EH check on his RPi](https://github.com/ldc-developers/ldc/issues/489#issuecomment-177632221), disabling it for now, until it can be fixed.  A lot of my remaining Android changes can be cherry-picked from [this recent PR upstream](https://github.com/D-Programming-Language/druntime/pull/1490). 

Other than that, [there's a workaround for a compile-time bug that shows up only when cross-compiling](https://gist.github.com/joakim-noah/d936d6a339426ad1fac3#file-druntime_ldc_arm-L9), [a workaround for a strange issue with signal-handling only when running D in a shared library](https://gist.github.com/joakim-noah/d936d6a339426ad1fac3#file-druntime_ldc_arm-L86), [three](https://gist.github.com/joakim-noah/d936d6a339426ad1fac3#file-druntime_ldc_arm-L102) [disabled](https://gist.github.com/joakim-noah/d936d6a339426ad1fac3#file-druntime_ldc_arm-L188) [test](https://gist.github.com/joakim-noah/d936d6a339426ad1fac3#file-druntime_ldc_arm-L197) blocks (the latter two pass but may corrupt memory and cause problems only when run in the same process as other tests, which is also reproducible with dmd upstream), [added a struct modifier because the clang EH header is different](https://gist.github.com/joakim-noah/d936d6a339426ad1fac3#file-druntime_ldc_arm-L115), [reverted to GCed exceptions because of a codegen issue with emulated TLS on Android](https://gist.github.com/joakim-noah/d936d6a339426ad1fac3#file-druntime_ldc_arm-L162), and [reworked the test runner to run all tests from a single process and so it can be called as a function by an Android apk](https://gist.github.com/joakim-noah/d936d6a339426ad1fac3#file-druntime_ldc_arm-L263).  I did not submit these because most should be looked into and fixed, while some would just make existing code messier and be too specific.
