### PR TITLE
Cache ARM EABI exception data

### DIFF
--- a/src/ldc/eh/libunwind.d
+++ b/src/ldc/eh/libunwind.d
@@ -247,7 +247,17 @@ struct NativeContext
         debug(EH_personality) printf("  - Found catch clause for %p\n", exception_struct);
 
         if (actions & _Unwind_Action.SEARCH_PHASE)
+        {
+            // Cache phase 1 data (TODO: take advantage of cache)
+            version (ARM_EABI_UNWINDER) with (exception_struct.unwind_info)
+            {
+                barrier_cache.sp = _Unwind_GetGR(context, UNWIND_STACK_REG);
+                barrier_cache.bitpattern[1] = ti_offset;
+                barrier_cache.bitpattern[3] = landingPadAddr;
+            }
+
             return _Unwind_Reason_Code.HANDLER_FOUND;
+        }
 
         if (!(actions & _Unwind_Action.CLEANUP_PHASE))
             fatalerror("Unknown phase");


### PR DESCRIPTION
Update ARM_EABI_UNWINDER code in EH personality so it caches handler data found during phase 1.  The cache is not used yet, but personality only works correctly when `barrier_cache.sp` is set.  See ldc-developers/ldc#489 for details.

Tested on a Raspberry Pi with Raspbian Jessie.

@klickverbot - with ldc-developers/ldc#1025 I see yours plans to work on this.  Do you want this to go further and make use of the cache?
