### PR TITLE
Really fix ARM EABI Exception Handling

### DIFF
--- a/src/ldc/arm_unwind.c
+++ b/src/ldc/arm_unwind.c
@@ -10,7 +10,7 @@
  * Authors:   David Nadlinger
  */
 
-#if defined(__arm__) && !defined(__USING_SJLJ_EXCEPTIONS__)
+#ifdef __ARM_EABI__
 
 #include <unwind.h>
 

--- a/src/ldc/eh/common.d
+++ b/src/ldc/eh/common.d
@@ -516,7 +516,7 @@ extern(C) auto eh_personality_common(NativeContext)(ref NativeContext nativeCont
 
             debug(EH_personality_verbose)
             {
-                printf("  - ip=%llx %d %d %llx\n", ip, block_start_offset,
+                printf("  - ip=%p %u %u %tx\n", ip, block_start_offset,
                     block_size, landingPadAddr);
             }
 

--- a/src/ldc/eh/libunwind.d
+++ b/src/ldc/eh/libunwind.d
@@ -223,7 +223,18 @@ struct NativeContext
     // As a further optimization step, we could look into caching that
     // result inside _d_exception.
     bool skipCatchComparison()       { return !isSearchPhase() && (actions & _Unwind_Action.HANDLER_FRAME) == 0; }
-    ptrdiff_t getCfaAddress()        { return _Unwind_GetCFA(context); }
+
+    ptrdiff_t getCfaAddress()
+    {
+        // libgcc _Unwind_GetCFA for ARM_EABI is a partial
+        // implementation, only valid during forced unwinds, so use
+        // stack pointer instead.
+        version (ARM_EABI_UNWINDER)
+            return _Unwind_GetGR(context, UNWIND_STACK_REG);
+        else
+            return _Unwind_GetCFA(context);
+    }
+
     Object getThrownObject()         { return exception_struct.exception_object; }
 
     void overrideThrownObject(Object newObject)

--- a/src/ldc/eh_asm.S
+++ b/src/ldc/eh_asm.S
@@ -1,0 +1,54 @@
+/**
+ * Exception handling support code that is best written in assembly
+ * goes here.
+ *
+ * Copyright: Copyright The LDC Developers 2016
+ * License:   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+ */
+
+/*
+ * Mark the resulting object file as not requiring execution
+ * permissions on stack memory. The absence of this section would mark
+ * the whole resulting library as requiring an executable stack,
+ * making it impossible to dynamically load druntime on several Linux
+ * platforms where this is forbidden due to security policies.
+ */
+
+#if (defined(__linux__) || defined(__FreeBSD__)) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+.previous
+#endif
+
+/*
+ * Called by our compiler-generate code to resume unwinding after a
+ * finally block (or dtor destruction block) has been run.  'ptr' (r0)
+ * is to a _d_exception.
+ *
+ *    void _d_eh_resume_unwind(void* ptr)
+ *
+ * _Unwind_Resume for ARM_EABI expects registers not to be clobbered
+ * by our cleanup routine, so need this wrapper to preserve scratch
+ * registers (7.4 [6 Note]) before entering it.
+ *
+ * Note: Current codegen of D catch landing pads are incompatible with
+ * GCC provided _Unwind_Resume because the LLVM inliner can create
+ * landing pads that advertise to catch more exceptions than are
+ * handled, falling into _d_eh_resume_unwind to find the real handler.
+ * _Unwind_Resume ignores the saved IP and resets it to the original
+ * call site in this frame, but we need the callsite of
+ * _d_eh_resume_unwind to find the next landing pad.  Workaround is to
+ * capture it, passing to _d_arm_eabi_end_cleanup as second arg.
+ */
+#ifdef __ARM_EABI__
+	// say we will preseve 8-byte stack when we push
+        .eabi_attribute 25, 1
+        .text
+	.global	_d_eh_resume_unwind
+	.align	2
+_d_eh_resume_unwind:
+	push	{r1-r3,lr}      // end_cleanup may trash these
+	mov	r1,lr           // callsite IP
+	bl	_d_arm_eabi_end_cleanup
+	pop	{r1-r3,lr}      // restore regs to state at entry
+	b	_Unwind_Resume  // r0 has returned ucb
+#endif //__ARM_EABI


### PR DESCRIPTION
I am sure there are other bugs with the complexity of code like this, but this PR makes all the exception handling failures in the test suite go way and allows std.exception -O3 unittest to work properly.

It would be really good to have @joakim-noah try this on Android.  There is a new file ldc/eh_asm.S that needs to be added to runtime/CMakeLists.txt.

One of the fixes is really a workaround for how D landing pads are getting merged by LLVM inliner.  It is probably worth looking at using LLVM resume instruction at end of landing pads.  See ldc-developers/ldc#1283 for further info.
