### PR TITLE
Support ARM AAPCS style va_list for C++ mangling

### DIFF
--- a/src/ldc/internal/vararg.di
+++ b/src/ldc/internal/vararg.di
@@ -21,3 +21,12 @@ version (AArch64)
         int __vr_offs;
     }
 }
+else version (ARM)
+{
+    // Need std::__va_list for C++ mangling compatability
+    // section AAPCS 7.1.4
+    extern (C++, std) struct __va_list
+    {
+        void *__ap;
+    }
+}

--- a/src/object.d
+++ b/src/object.d
@@ -75,6 +75,17 @@ version (LDC)
             alias __va_list = ldc.internal.vararg.std.__va_list;
         }
     }
+    else version (ARM)
+    {
+        // Darwin does not use __va_list
+        version( iOS ) {}
+        else version( WatchOS ) {}
+        else
+        {
+            static import ldc.internal.vararg;
+            alias __va_list = ldc.internal.vararg.std.__va_list;
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
AAPCS defines va_list as a std::__va_list struct, which is needed to interface with C++.  This builds on @redstar 's recent change for AArch64 which has a similar situation.

Must be pulled with similar named ldc PR.
