### PR TITLE
fix TLS alignment for Windows 8.0 or below

### DIFF
--- a/src/core/sys/windows/threadaux.d
+++ b/src/core/sys/windows/threadaux.d
@@ -319,6 +319,16 @@ public:
         return tls;
     }
 
+    // get the address of the entry in the TLS array for the current thread
+    // use C mangling to access it from msvc.c
+    extern(C) void** GetTlsEntryAdr()
+    {
+        if( void** teb = getTEB() )
+            if( void** tlsarray = cast(void**) teb[11] )
+                return tlsarray + _tls_index;
+        return null;
+    }
+
     ///////////////////////////////////////////////////////////////////
     // run rt_moduleTlsCtor in the context of the given thread
     void thread_moduleTlsCtor( uint id )

--- a/src/ldc/msvc.c
+++ b/src/ldc/msvc.c
@@ -89,7 +89,90 @@ __declspec(allocate(".CRT$XIY")) static _PF _ctor = &ctor;
 __declspec(allocate(".CRT$XTY")) static _PF _dtor = &dtor;
 
 #pragma data_seg(pop)
-#endif
+
+/*********************************************************
+ * Windows before Windows 8.1 does not support TLS alignment to anything
+ *  higher than 8/16 bytes for Win32 and Win64, respectively.
+ *  Some optimizations in LLVM (e.g. using aligned XMM access) do require
+ *  higher alignments, though. In addition, the programmer can use align()
+ *  to specify even larger requirements.
+ * Fixing the alignment is done by adding a TLS callback that allocates
+ *  a new copy of the TLS segment if the current one is not aligned properly.
+ */
+
+__declspec(thread) void* originalTLS; // saves the address of the original TLS to restore it before termination
+
+extern void** GetTlsEntryAdr();
+
+BOOL WINAPI fix_tlsAlignment(HINSTANCE hModule, DWORD  fdwReason, LPVOID lpvReserved)
+{
+    if (fdwReason == DLL_PROCESS_DETACH || fdwReason == DLL_THREAD_DETACH)
+    {
+        if (originalTLS)
+        {
+            // restore original pointer
+            void** tlsAdr = GetTlsEntryAdr();
+            void* allocAdr = ((void**) *tlsAdr)[-1];
+            *tlsAdr = originalTLS;
+            HeapFree(GetProcessHeap(), 0, allocAdr);
+        }
+    }
+    else
+    {
+        // crawl through the image to find the TLS alignment
+        char* imageBase = (char*) hModule;
+        PIMAGE_DOS_HEADER pDosHeader = (PIMAGE_DOS_HEADER) hModule;
+        PIMAGE_NT_HEADERS pNtHeaders = (PIMAGE_NT_HEADERS) (imageBase + pDosHeader->e_lfanew);
+        PIMAGE_SECTION_HEADER pSectionHeader = (PIMAGE_SECTION_HEADER) (pNtHeaders + 1);
+        PIMAGE_DATA_DIRECTORY dataDir = pNtHeaders->OptionalHeader.DataDirectory + IMAGE_DIRECTORY_ENTRY_TLS;
+        if (dataDir->VirtualAddress) // any TLS entry
+        {
+            PIMAGE_TLS_DIRECTORY tlsDir = (PIMAGE_TLS_DIRECTORY) (imageBase + dataDir->VirtualAddress);
+            int alignShift = ((tlsDir->Characteristics >> 20) & 0xf);
+
+            if (alignShift)
+            {
+                int alignment = 1 << (alignShift - 1);
+                void** tlsAdr = GetTlsEntryAdr();
+                if ((SIZE_T)*tlsAdr & (alignment - 1))
+                {
+                    // this implementation does about the same as Windows 8.1.
+                    HANDLE heap = GetProcessHeap();
+                    SIZE_T tlsSize = tlsDir->EndAddressOfRawData - tlsDir->StartAddressOfRawData + tlsDir->SizeOfZeroFill;
+                    SIZE_T allocSize = tlsSize + alignment + sizeof(void*);
+                    void* p = HeapAlloc(heap, 0, allocSize);
+                    if (!p)
+                        return 0;
+
+                    void* aligned = (void*) (((SIZE_T) p + alignment + sizeof(PVOID)) & ~(alignment - 1));
+                    void* old = *tlsAdr;
+                    ((void**) aligned)[-1] = p;    // save base pointer for freeing
+                    memcpy(aligned, old, tlsSize);
+                    *tlsAdr = aligned;
+                    originalTLS = old;
+                }
+            }
+        }
+    }
+    return 1;
+}
+
+// the C++ TLS callbacks are written to ".CRT$XLC", but actually start after ".CRT$XLA".
+//  Using ".CRT$XLB" allows this to come first in the array of TLS callbacks. This
+//  guarantees that pointers saved within C++ TLS callbacks are not pointing into
+//  abandoned memory
+
+typedef BOOL WINAPI _TLSCB(HINSTANCE, DWORD, LPVOID);
+
+#pragma data_seg(push)
+
+#pragma section(".CRT$XLB", long, read)
+
+#pragma data_seg(".CRT$XLB")
+__declspec(allocate(".CRT$XLB")) static _TLSCB* _pfix_tls = &fix_tlsAlignment;
+
+#pragma data_seg(pop)
 
 #endif
 
+#endif // _WIN32


### PR DESCRIPTION
Even though documented in MSDN for VS2003 (https://msdn.microsoft.com/de-de/library/83ythb65%28v=vs.71%29.aspx), TLS alignment seems not to be implemented before Windows 8.1.

Both the align() attibute aswell as LLVM optimizations require alignments higher than the default, so to not exclude Windows 7 users from using executables built with LDC, this allocates another TLS segment aligned appropraitely and replaces the one allocated by the OS.
