### PR TITLE
Mark memory management functions as @weak.

### DIFF
--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -20,6 +20,7 @@ import core.memory;
 debug(PRINTF) import core.stdc.stdio;
 static import rt.tlsgc;
 version(LDC) import ldc.intrinsics;
+version(LDC) import ldc.attributes;
 
 alias BlkInfo = GC.BlkInfo;
 alias BlkAttr = GC.BlkAttr;
@@ -62,6 +63,7 @@ extern (C) void lifetime_init()
  *
  */
 extern (C) void* _d_allocmemory(size_t sz)
+@weak // LDC
 {
     return GC.malloc(sz);
 }
@@ -74,6 +76,7 @@ version (LDC)
  * for allocating a single POD value
  */
 extern (C) void* _d_allocmemoryT(TypeInfo ti)
+@weak // LDC
 {
     return GC.malloc(ti.tsize(), !(ti.flags() & 1) ? BlkAttr.NO_SCAN : 0);
 }
@@ -85,6 +88,7 @@ extern (C) void* _d_allocmemoryT(TypeInfo ti)
  *
  */
 extern (C) Object _d_newclass(const ClassInfo ci)
+@weak // LDC
 {
     void* p;
 
@@ -159,6 +163,7 @@ private extern (D) alias void function (Object) fp_t;
  *
  */
 extern (C) void _d_delclass(Object* p)
+@weak // LDC
 {
     if (*p)
     {
@@ -194,6 +199,7 @@ extern (C) void _d_delclass(Object* p)
  * but doesn't have an overloaded delete operator.
  */
 extern (C) void _d_delstruct(void** p, TypeInfo_Struct inf)
+@weak // LDC
 {
     if (*p)
     {
@@ -753,6 +759,7 @@ void __doPostblit(void *ptr, size_t len, const TypeInfo ti)
  * actually be stored once the resizing is done.
  */
 extern(C) size_t _d_arraysetcapacity(const TypeInfo ti, size_t newcapacity, void[]* p)
+@weak // LDC
 in
 {
     assert(ti);
@@ -931,6 +938,7 @@ Lcontinue:
  * ti is the type of the resulting array, or pointer to element.
  */
 extern (C) void[] _d_newarrayU(const TypeInfo ti, size_t length) pure nothrow
+@weak // LDC
 {
     version(LDC) auto tinext = unqualify(unqualify(ti).next); else
     auto tinext = unqualify(ti.next);
@@ -999,6 +1007,7 @@ Lcontinue:
  * (For when the array is initialized to 0)
  */
 extern (C) void[] _d_newarrayT(const TypeInfo ti, size_t length) pure nothrow
+@weak // LDC
 {
     void[] result = _d_newarrayU(ti, length);
     version(LDC) auto tinext = unqualify(unqualify(ti).next); else
@@ -1014,6 +1023,7 @@ extern (C) void[] _d_newarrayT(const TypeInfo ti, size_t length) pure nothrow
  * For when the array has a non-zero initializer.
  */
 extern (C) void[] _d_newarrayiT(const TypeInfo ti, size_t length) pure nothrow
+@weak // LDC
 {
     import core.internal.traits : TypeTuple;
 
@@ -1049,6 +1059,7 @@ extern (C) void[] _d_newarrayiT(const TypeInfo ti, size_t length) pure nothrow
  *
  */
 void[] _d_newarrayOpT(alias op)(const TypeInfo ti, size_t[] dims)
+@weak // LDC
 {
     debug(PRINTF) printf("_d_newarrayOpT(ndims = %d)\n", dims.length);
     if (dims.length == 0)
@@ -1092,6 +1103,7 @@ void[] _d_newarrayOpT(alias op)(const TypeInfo ti, size_t[] dims)
  *
  */
 extern (C) void[] _d_newarraymTX(const TypeInfo ti, size_t[] dims)
+@weak // LDC
 {
     debug(PRINTF) printf("_d_newarraymT(dims.length = %d)\n", dims.length);
 
@@ -1108,6 +1120,7 @@ extern (C) void[] _d_newarraymTX(const TypeInfo ti, size_t[] dims)
  *
  */
 extern (C) void[] _d_newarraymiTX(const TypeInfo ti, size_t[] dims)
+@weak // LDC
 {
     debug(PRINTF) printf("_d_newarraymiT(dims.length = %d)\n", dims.length);
 
@@ -1124,6 +1137,7 @@ extern (C) void[] _d_newarraymiTX(const TypeInfo ti, size_t[] dims)
  * This is an optimization to avoid things needed for arrays like the __arrayPad(size).
  */
 extern (C) void* _d_newitemU(in TypeInfo _ti)
+@weak // LDC
 {
     auto ti = unqualify(_ti);
     auto flags = !(ti.flags & 1) ? BlkAttr.NO_SCAN : 0;
@@ -1143,6 +1157,7 @@ extern (C) void* _d_newitemU(in TypeInfo _ti)
 
 /// Same as above, zero initializes the item.
 extern (C) void* _d_newitemT(in TypeInfo _ti)
+@weak // LDC
 {
     auto p = _d_newitemU(_ti);
     memset(p, 0, _ti.tsize);
@@ -1151,6 +1166,7 @@ extern (C) void* _d_newitemT(in TypeInfo _ti)
 
 /// Same as above, for item with non-zero initializer.
 extern (C) void* _d_newitemiT(in TypeInfo _ti)
+@weak // LDC
 {
     auto p = _d_newitemU(_ti);
     auto init = _ti.init();
@@ -1173,6 +1189,7 @@ struct Array
  * This function has been replaced by _d_delarray_t
  */
 extern (C) void _d_delarray(void[]* p)
+@weak // LDC
 {
     _d_delarray_t(p, null);
 }
@@ -1194,6 +1211,7 @@ debug(PRINTF)
  *
  */
 extern (C) void _d_delarray_t(void[]* p, const TypeInfo_Struct ti)
+@weak // LDC
 {
     if (p)
     {
@@ -1249,6 +1267,7 @@ unittest
  *
  */
 extern (C) void _d_delmemory(void* *p)
+@weak // LDC
 {
     if (*p)
     {
@@ -1276,6 +1295,7 @@ extern (C) void _d_callinterfacefinalizer(void *p)
  *
  */
 extern (C) void _d_callfinalizer(void* p)
+@weak // LDC
 {
     rt_finalize( p );
 }
@@ -1477,6 +1497,7 @@ extern (C) void rt_finalizeFromGC(void* p, size_t size, uint attr)
  * Resize dynamic arrays with 0 initializers.
  */
 extern (C) void[] _d_arraysetlengthT(const TypeInfo ti, size_t newlength, void[]* p)
+@weak // LDC
 in
 {
     assert(ti);
@@ -1668,6 +1689,7 @@ Loverflow:
  *      ...             initializer
  */
 extern (C) void[] _d_arraysetlengthiT(const TypeInfo ti, size_t newlength, void[]* p)
+@weak // LDC
 in
 {
     assert(!(*p).length || (*p).ptr);
@@ -1872,6 +1894,7 @@ Loverflow:
  * Append y[] to array x[]
  */
 extern (C) void[] _d_arrayappendT(const TypeInfo ti, ref byte[] x, byte[] y)
+@weak // LDC
 {
     auto length = x.length;
     version(LDC) auto tinext = unqualify(unqualify(ti).next); else
@@ -1974,6 +1997,7 @@ size_t newCapacity(size_t newlength, size_t size)
  */
 extern (C)
 byte[] _d_arrayappendcTX(const TypeInfo ti, ref byte[] px, size_t n)
+@weak // LDC
 {
     // This is a cut&paste job from _d_arrayappendT(). Should be refactored.
 
@@ -2158,6 +2182,7 @@ extern (C) void[] _d_arrayappendwd(ref byte[] x, dchar c)
  *
  */
 extern (C) byte[] _d_arraycatT(const TypeInfo ti, byte[] x, byte[] y)
+@weak // LDC
 out (result)
 {
     version(LDC) auto tinext = unqualify(unqualify(ti).next); else
@@ -2227,6 +2252,7 @@ body
  *
  */
 extern (C) void[] _d_arraycatnTX(const TypeInfo ti, byte[][] arrs)
+@weak // LDC
 {
     size_t length;
     version(LDC) auto tinext = unqualify(unqualify(ti).next); else
@@ -2268,6 +2294,7 @@ extern (C) void[] _d_arraycatnTX(const TypeInfo ti, byte[][] arrs)
  */
 extern (C)
 void* _d_arrayliteralTX(const TypeInfo ti, size_t length)
+@weak // LDC
 {
     version(LDC) auto tinext = unqualify(unqualify(ti).next); else
     auto tinext = unqualify(ti.next);


### PR DESCRIPTION
When these functions are @weak, user code can override them.

Such a mechanism is used in DMD: https://github.com/D-Programming-Language/dmd/blob/master/src/root/rmem.d#L166-L193
The PR is for druntime used for LDC0.17, so that we can use it while compiling LDC master (after detection of the availability of @weak).
Enabling that DMD specific code for LDC results in quite a large compiler performance improvement.
I am using this in Weka's version of LDC to speed up the compiler by ~20% on a unittest case that takes more than a minute to compile.
In the forums, someone mentioned a large performance boost for DMD when built with LDC+this modification.

I cannot judge well whether this is just a hack or not. Manual memory management by the user by overriding these druntime calls is very specific and super tricky, I think. Probably it only works without any issues for LDC because GC is turned off, and memory is never (?) de-allocated.
Otoh, DMD seems to output all symbols as weak, and as such this change makes LDC on Mac and Unix a little more like DMD (on Windows recently we started emitting all symbols with weak-like linkage).

The functions marked with @weak are all functions from lifetime.d that allocate/free memory, after some inspection. Please review whether I've missed some, or whether some should not be marked @weak.
AA allocation functions are elsewhere and are not included in this PR.

(ping @klickverbot )
