### PR TITLE
Solaris: fix readdir for x64 OS.

### DIFF
--- a/src/core/sys/posix/dirent.d
+++ b/src/core/sys/posix/dirent.d
@@ -160,14 +160,21 @@ else version (Solaris)
         char* dd_buf;
     }
 
-    static if (__USE_LARGEFILE64)
+    version (D_LP64)
     {
-        dirent* readdir64(DIR*);
-        alias readdir64 readdir;
+        dirent* readdir(DIR*);
     }
     else
     {
-        dirent* readdir(DIR*);
+        static if (__USE_LARGEFILE64)
+        {
+            dirent* readdir64(DIR*);
+            alias readdir64 readdir;
+        }
+        else
+        {
+            dirent* readdir(DIR*);
+        }
     }
 }
 else version( CRuntime_Bionic )

--- a/src/core/sys/posix/dirent.d
+++ b/src/core/sys/posix/dirent.d
@@ -163,6 +163,7 @@ else version (Solaris)
     version (D_LP64)
     {
         dirent* readdir(DIR*);
+        alias readdir64 = readdir;
     }
     else
     {


### PR DESCRIPTION
Patch by @nykytenko, originally submitted at dlang#1566.
