### PR TITLE
Solaris: fix getpwuid_r and getpwnam_r call to POSIX standard version.

### DIFF
--- a/src/core/sys/posix/pwd.d
+++ b/src/core/sys/posix/pwd.d
@@ -145,8 +145,12 @@ else version( FreeBSD )
 }
 else version (Solaris)
 {
-    int getpwnam_r(in char*, passwd*, char*, size_t, passwd**);
-    int getpwuid_r(uid_t, passwd*, char*, size_t, passwd**);
+    alias getpwnam_r = __posix_getpwnam_r;
+    alias getpwuid_r = __posix_getpwuid_r;
+
+    // POSIX.1c standard version of the functions
+    int __posix_getpwnam_r(in char*, passwd*, char*, size_t, passwd**);
+    int __posix_getpwuid_r(uid_t, passwd*, char*, size_t, passwd**);
 }
 else version( CRuntime_Bionic )
 {


### PR DESCRIPTION
Solaris POSIX standard version of the functions `getpwnam_r` and  `getpwuid_r` are 
`__posix_getpwnam_r` and `__posix_getpwuid_r`.
This changes fix phobos std.path unittest error.
