### PR TITLE
Fix issue #966 (initializing class instances twice)

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -1052,11 +1052,6 @@ class TypeInfo_Class : TypeInfo
         if (m_flags & 64) // abstract
             return null;
         Object o = _d_newclass(this);
-      version (LDC)
-      {
-        // initialize manually as LDC's _d_newclass() doesn't
-        (cast(void*)o)[0 .. initializer.length] = initializer[];
-      }
         if (m_flags & 8 && defaultConstructor)
         {
             defaultConstructor(o);

--- a/src/object.d
+++ b/src/object.d
@@ -1052,6 +1052,11 @@ class TypeInfo_Class : TypeInfo
         if (m_flags & 64) // abstract
             return null;
         Object o = _d_newclass(this);
+      version (LDC)
+      {
+        // initialize manually as LDC's _d_newclass() doesn't
+        (cast(void*)o)[0 .. initializer.length] = initializer[];
+      }
         if (m_flags & 8 && defaultConstructor)
         {
             defaultConstructor(o);

--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -132,7 +132,15 @@ extern (C) Object _d_newclass(const ClassInfo ci)
     }
 
     // initialize it
+  version (LDC)
+  {
+    // LDC initializes it in DtoNewClass(), so no need to pre-initialize it here
+    // (LDC issue #966)
+  }
+  else
+  {
     p[0 .. ci.initializer.length] = ci.initializer[];
+  }
 
     debug(PRINTF) printf("initialization done\n");
     return cast(Object) p;


### PR DESCRIPTION
We initialize the instance in `DtoNewClass()`, so elide pre-initializing it in `_d_newclass()`.
