### PR TITLE
Fix no stack trace on windows

### DIFF
--- a/src/core/runtime.d
+++ b/src/core/runtime.d
@@ -760,11 +760,17 @@ Throwable.TraceInfo defaultTraceHandler( void* ptr = null )
     {
         version (Win64)
         {
-            static enum FIRSTFRAME = 4;
+            version (LDC)
+                static enum FIRSTFRAME = 1;
+            else
+                static enum FIRSTFRAME = 4;
         }
         else version (Win32)
         {
-            static enum FIRSTFRAME = 0;
+            version (LDC)
+                static enum FIRSTFRAME = 1;
+            else
+                static enum FIRSTFRAME = 0;
         }
         import core.sys.windows.windows : CONTEXT;
         auto s = new StackTrace(FIRSTFRAME, cast(CONTEXT*)ptr);


### PR DESCRIPTION
Tested in win32 and win64 with '-g' option.

(I did not touch the assembly code but the code modified automaticly.)

Update:
The added code is simply copied from _d_throw_exception(druntime/src/ldc/eh/libunwind.d)

Update2:
win32 must with '-g -disable-fp-elim' option

Update3:
druntime/src/core/runtime.d