### PR TITLE
WIP: Allow disabling exception trace info via --DRT-traceContext=off

### DIFF
--- a/src/ldc/eh/config.d
+++ b/src/ldc/eh/config.d
@@ -1,0 +1,11 @@
+module ldc.eh.config;
+
+import rt.config;
+
+package __gshared bool traceContext = true;
+
+shared static this()
+{
+    if (rt_configOption("traceContext") == "off")
+        traceContext = false;
+}

--- a/src/ldc/eh/libunwind.d
+++ b/src/ldc/eh/libunwind.d
@@ -491,7 +491,8 @@ void _d_throw_exception(Object e)
 
     auto throwable = cast(Throwable) e;
 
-    if (throwable.info is null && cast(byte*)throwable !is typeid(throwable).init.ptr)
+    static import ldc.eh.config;
+    if (ldc.eh.config.traceContext && throwable.info is null && cast(byte*)throwable !is typeid(throwable).init.ptr)
         throwable.info = _d_traceContext();
 
     auto exc_struct = ExceptionStructPool.malloc();


### PR DESCRIPTION
This should be more or less what @rainers suggested [here](https://github.com/ldc-developers/druntime/pull/85#discussion_r96054143). Seems to work after a single quick test. Should probably be upstreamed.