### PR TITLE
Check fiber migration on Android/ARM too

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -3905,6 +3905,11 @@ version( LDC )
         version( X86 ) version = CheckFiberMigration;
         version( X86_64 ) version = CheckFiberMigration;
     }
+
+    version( Android )
+    {
+        version( ARM ) version = CheckFiberMigration;
+    }
 }
 
 // Fiber support for SjLj style exceptions


### PR DESCRIPTION
I get the message about it not being safe when running the druntime tests if this isn't set, probably because of the emulated TLS scheme I'm using and the compiler messing with that.  I have not looked into the details of what's happening though.