### PR TITLE
Add interface to the (un)poison functions of AddressSanitizer compiler-rt lib

### DIFF
--- a/src/ldc/asan.d
+++ b/src/ldc/asan.d
@@ -1,0 +1,27 @@
+/**
+ * Contains forward references to the AddressSanitizer interface.
+ * See compiler-rt/include/sanitizer/asan_interface.h
+ *
+ * Copyright: Authors 2017-2017
+ * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Authors:   LDC Developers
+ */
+module ldc.asan;
+
+@system:
+@nogc:
+extern (C):
+
+// Poisons memory region [addr, addr+size) for AddressSanitizer.
+// Method is NOT thread-safe in the sense that no two threads can
+// (un)poison memory in the same memory region simultaneously.
+void __asan_poison_memory_region(const(void*) addr, size_t size);
+
+// Unpoisons memory region [addr, addr+size) for AddressSanitizer.
+// Method is NOT thread-safe in the sense that no two threads can
+// (un)poison memory in the same memory region simultaneously.
+void __asan_unpoison_memory_region(const(void*) addr, size_t size);
+
+// Returns 1 if the byte at addr is poisoned for AddressSanitizer.
+// Otherwise returns 0.
+int __asan_address_is_poisoned(const(void*) addr);


### PR DESCRIPTION
After this, the only thing left to do to have AddressSanitizer work for GC'd memory is to add calls to (un)poison GC'd memory.

My plan is to add an "asan" GC (like the "conservative" and "manual" GCs that we have currently), that marks all pool memory as poisoned, reserves S+redzone bytes of memory for an allocation of size S, and unpoisons S bytes. But that's future work. :)