### PR TITLE
core.stdc.stdarg: don't suppress static assert for unsupported arches

### DIFF
--- a/src/core/stdc/stdarg.d
+++ b/src/core/stdc/stdarg.d
@@ -815,8 +815,11 @@ else version (X86_64)
     }
   }
 }
+else version (ARM)     {}
+else version (AArch64) {}
+else version (AnyPPC)  {}
+else version (MIPS64)  {}
 else
 {
-    version (LDC) {} else
     static assert(false, "Unsupported platform");
 }


### PR DESCRIPTION
This could be further scoped to just `LDC` but since realistically nobody's going to use this heavily hacked up module with any other compiler, no need to further complicate this right now.  If and when these patches are merged upstream, somebody can figure that out.