### PR TITLE
Guard unittest for atomicLoad() of int[].

### DIFF
--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -1946,7 +1946,10 @@ version( unittest )
         static assert(is(typeof(atomicLoad(p)) == shared(int)*));
 
         shared int[] a;
-        static assert(is(typeof(atomicLoad(a)) == shared(int)[]));
+        static if (__traits(compiles, atomicLoad(a)))
+        {
+            static assert(is(typeof(atomicLoad(a)) == shared(int)[]));
+        }
 
         static struct S { int* _impl; }
         shared S s;


### PR DESCRIPTION
On 64 bit platforms int[] has size 128 bit. Sadly, not all of these
platforms support cas with 128 bit, which breaks the unit test.
Example is ppc64.

(cherry picked from commit 5172f13c0798da61fa01a1f059b552f3e65b7f75)