### PR TITLE
[ltsmaster] Fix va_arg() for PowerPC.

### DIFF
--- a/src/core/stdc/stdarg.d
+++ b/src/core/stdc/stdarg.d
@@ -449,9 +449,14 @@ version( LDC )
              * http://refspecs.linuxfoundation.org/ELF/ppc64/PPC-elf64abi-1.9.html#PARAM-PASS
              */
 
-            // This works for all types because only the rules for non-floating,
-            // non-vector types are used.
-            auto p = (T.sizeof < size_t.sizeof ? ap + (size_t.sizeof - T.sizeof) : ap);
+            // Chapter 3.1.4 and 3.2.3: Alignment may require the va_list pointer to first
+            // be aligned before accessing a value.
+            if (T.alignof >= 8)
+                ap = cast(va_list)((cast(size_t)ap + 7) & ~7);
+            version( BigEndian )
+                auto p = (T.sizeof < size_t.sizeof ? ap + (size_t.sizeof - T.sizeof) : ap);
+            version( LittleEndian )
+                auto p = ap;
             T arg = *cast(T*)p;
             ap += (T.sizeof + size_t.sizeof - 1) & ~(size_t.sizeof - 1);
             return arg;
@@ -581,9 +586,14 @@ version( LDC )
              * http://refspecs.linuxfoundation.org/ELF/ppc64/PPC-elf64abi-1.9.html#PARAM-PASS
              */
 
-            // This works for all types because only the rules for non-floating,
-            // non-vector types are used.
-            auto p = (tsize < size_t.sizeof ? ap + (size_t.sizeof - tsize) : ap);
+            // Chapter 3.1.4 and 3.2.3: Alignment may require the va_list pointer to first
+            // be aligned before accessing a value.
+            if (ti.alignof >= 8)
+                ap = cast(va_list)((cast(size_t)ap + 7) & ~7);
+            version( BigEndian )
+                auto p = (T.sizeof < size_t.sizeof ? ap + (size_t.sizeof - T.sizeof) : ap);
+            version( LittleEndian )
+                auto p = ap;
             ap += (tsize + size_t.sizeof - 1) & ~(size_t.sizeof - 1);
         }
         else version( MIPS64 )


### PR DESCRIPTION
This fixes a failure in ldc_cabi1.d test. The value loaded for byte
and word sized parameters were wrong.