### PR TITLE
Fix rt.backtrace.dwarf

### DIFF
--- a/src/rt/backtrace/dwarf.d
+++ b/src/rt/backtrace/dwarf.d
@@ -91,23 +91,37 @@ else
     int ret = 0;
     foreach (size_t i; 0 .. callstack.length)
     {
-        char[1536] buffer = void; buffer[0] = 0;
-        char[256] addressBuffer = void; addressBuffer[0] = 0;
+        char[1536] buffer = void;
+        size_t bufferLength = 0;
+
+        void appendToBuffer(Args...)(const(char)* format, Args args)
+        {
+            const count = snprintf(buffer.ptr + bufferLength, buffer.length - bufferLength, format, args);
+            assert(count >= 0);
+            bufferLength += count;
+            if (bufferLength >= buffer.length)
+                bufferLength = buffer.length - 1;
+        }
 
         if (locations.length > 0 && locations[i].line != -1)
-            snprintf(addressBuffer.ptr, addressBuffer.length, "%.*s:%d ", cast(int) locations[i].file.length, locations[i].file.ptr, locations[i].line);
+        {
+            appendToBuffer("%.*s:%d ", cast(int) locations[i].file.length, locations[i].file.ptr, locations[i].line);
+        }
         else
-            addressBuffer[] = "??:? \0";
+        {
+            buffer[0 .. 5] = "??:? ";
+            bufferLength = 5;
+        }
 
         char[1024] symbolBuffer = void;
-        int bufferLength;
         auto symbol = getDemangledSymbol(frameList[i][0 .. strlen(frameList[i])], symbolBuffer);
         if (symbol.length > 0)
-            bufferLength = snprintf(buffer.ptr, buffer.length, "%s%.*s [0x%x]", addressBuffer.ptr, cast(int) symbol.length, symbol.ptr, callstack[i]);
-        else
-            bufferLength = snprintf(buffer.ptr, buffer.length, "%s[0x%x]", addressBuffer.ptr, callstack[i]);
+            appendToBuffer("%.*s ", cast(int) symbol.length, symbol.ptr);
 
-        assert(bufferLength >= 0);
+        static if (size_t.sizeof == 8)
+            appendToBuffer("[0x%llx]", callstack[i]);
+        else
+            appendToBuffer("[0x%x]", callstack[i]);
 
         auto output = buffer[0 .. bufferLength];
         auto pos = i;


### PR DESCRIPTION
Cherry-pick of https://github.com/dlang/druntime/pull/2151 (still pending).

I don't know if the fixed [bug](https://github.com/dlang/druntime/pull/2151#discussion_r176944607) has the potential of being the cause for the EH issue on ARM and other EH strangeness, but it could have caused a segfault due to reading 250 bytes past the `??:? \0` string constant, if I studied the code correctly.