### PR TITLE
[ltsmaster] Change use of non-standard version MIPS to MIPS32.

### DIFF
--- a/src/core/stdc/config.d
+++ b/src/core/stdc/config.d
@@ -136,7 +136,7 @@ else version( LDC )
         alias real c_long_double;
     else version( ARM )
         alias real c_long_double;
-    else version( MIPS )
+    else version( MIPS32 )
         alias real c_long_double;
     else version( MIPS64 )
         alias real c_long_double;

--- a/src/core/sys/posix/setjmp.d
+++ b/src/core/sys/posix/setjmp.d
@@ -78,7 +78,7 @@ version( CRuntime_Glibc )
     {
         alias long[64] __jmp_buf;
     }
-    else version (MIPS)
+    else version (MIPS32)
     {
         struct __jmp_buf
         {

--- a/src/core/sys/posix/sys/msg.d
+++ b/src/core/sys/posix/sys/msg.d
@@ -83,7 +83,7 @@ else version(HPPA)
     };
 
 }
-else version(MIPS)
+else version(MIPS32)
 {
     // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/mips/bits/msq.h
     alias c_ulong msgqnum_t;

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -3237,7 +3237,7 @@ private void* getStackTop() nothrow
         {
             return __asm!(void *)("mr $0, 1", "=r");
         }
-        else version (MIPS)
+        else version (MIPS32)
         {
             return __asm!(void *)("move $0, $$sp", "=r");
         }

--- a/src/rt/sections_elf_shared.d
+++ b/src/rt/sections_elf_shared.d
@@ -965,7 +965,7 @@ else version(PPC)
     enum TLS_DTV_OFFSET = 0x8000;
 else version(PPC64)
     enum TLS_DTV_OFFSET = 0x8000;
-else version(MIPS)
+else version(MIPS32)
     enum TLS_DTV_OFFSET = 0x8000;
 else version(MIPS64)
     enum TLS_DTV_OFFSET = 0x8000;


### PR DESCRIPTION
All places are already changed in master branch.