### PR TITLE
MIPS32: Fix another assembly warning.

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -3378,7 +3378,7 @@ private void* getStackTop() nothrow @nogc
         {
             return __asm!(void *)("mr $0, 1", "=r");
         }
-        else version (MIPS)
+        else version (MIPS32)
         {
             return __asm!(void *)(".set noat; move $0, $$sp; .set at", "=r");
         }

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -3380,7 +3380,7 @@ private void* getStackTop() nothrow @nogc
         }
         else version (MIPS)
         {
-            return __asm!(void *)("move $0, $$sp", "=r");
+            return __asm!(void *)(".set noat; move $0, $$sp; .set at", "=r");
         }
         else version (MIPS64)
         {


### PR DESCRIPTION
(cherry picked from commit 92977be98098719dcdf2d02e9d0ed502d2ad0d63)