### PR TITLE
[MIPS32] fix `fiber_switchContext` to work with PIC

### DIFF
--- a/src/core/threadasm.S
+++ b/src/core/threadasm.S
@@ -522,6 +522,10 @@ fiber_switchContext:
 
     addiu $sp, $sp, (10 * 4)
 
+    #ifdef __PIC__
+        move $t9, $ra
+    #endif
+
     jr $ra // return
 
 #elif defined(__arm__) && defined(__ARM_EABI__)


### PR DESCRIPTION
According to this https://www.linux-mips.org/wiki/PIC_code the `$t9` register must contain the address of the function called.