### PR TITLE
[Trivial] Fix druntime for dragonflybsd

### DIFF
--- a/src/core/sys/posix/pwd.d
+++ b/src/core/sys/posix/pwd.d
@@ -240,12 +240,8 @@ else version( OpenBSD )
 }
 else version( DragonFlyBSD )
 {
-    alias getpwnam_r = __posix_getpwnam_r;
-    alias getpwuid_r = __posix_getpwuid_r;
-
-    // POSIX.1c standard version of the functions
-    int __posix_getpwnam_r(in char*, passwd*, char*, size_t, passwd**);
-    int __posix_getpwuid_r(uid_t, passwd*, char*, size_t, passwd**);
+    int getpwnam_r(in char*, passwd*, char*, size_t, passwd**);
+    int getpwuid_r(uid_t, passwd*, char*, size_t, passwd**);
 }
 else version (Solaris)
 {


### PR DESCRIPTION
This was possibly caused by manually merging the wrong part/segment. This issue is not present in [upstream dmd-druntime version](https://github.com/dlang/druntime/blob/master/src/core/sys/posix/pwd.d#L243).

FYI: I finally got around to testing ldc on dragonfly (i was waiting until the changes in dlang landed, and everything got merged into ldc-1.9.0 :-), i thought that would be the easiest transition.