### PR TITLE
[Trivial] Backport dlang druntime PR 2107

### DIFF
--- a/src/core/sys/dragonflybsd/pthread_np.d
+++ b/src/core/sys/dragonflybsd/pthread_np.d
@@ -4,7 +4,7 @@
  * Authors: Martin Nowak,Diederik de Groot(port:DragonFlyBSD)
  * Copied:  From core/sys/freebsd/sys
  */
-module core.sys.dragonflybsd.pthread;
+module core.sys.dragonflybsd.pthread_np;
 
 version (DragonFlyBSD):
 


### PR DESCRIPTION
Backport dlang druntime [PR2107](https://github.com/dlang/druntime/pull/2107)
Platform: DragonFlyBSD