### PR TITLE
ldc.llvmasm: Add @trusted __asm_trusted

### DIFF
--- a/src/ldc/llvmasm.di
+++ b/src/ldc/llvmasm.di
@@ -10,6 +10,9 @@ pragma(LDC_inline_asm)
     void __asm()(const(char)[] asmcode, const(char)[] constraints, ...) pure nothrow @nogc;
     T __asm(T)(const(char)[] asmcode, const(char)[] constraints, ...) pure nothrow @nogc;
 
+    void __asm_trusted()(const(char)[] asmcode, const(char)[] constraints, ...) @trusted pure nothrow @nogc;
+    T __asm_trusted(T)(const(char)[] asmcode, const(char)[] constraints, ...) @trusted pure nothrow @nogc;
+
     template __asmtuple(T...)
     {
         __asmtuple_t!(T) __asmtuple(const(char)[] asmcode, const(char)[] constraints, ...);


### PR DESCRIPTION
To get rid of the `() @trusted { __asm(...); } ()` workarounds.