### PR TITLE
Add FreeBSD/aarch64 support

### DIFF
--- a/src/core/sys/freebsd/execinfo.d
+++ b/src/core/sys/freebsd/execinfo.d
@@ -25,7 +25,7 @@ extern (D) int backtrace(void** buffer, int size)
         asm nothrow @trusted { mov p[EBP], EBP; }
     else version (D_InlineAsm_X86_64)
         asm nothrow @trusted { mov p[RBP], RBP; }
-    else version (AArch64) {
+    else version (AArch64) { // LDC
         import ldc.llvmasm;
         __asm("str x29, $0", "=*m", &p);
     } else

--- a/src/core/sys/freebsd/execinfo.d
+++ b/src/core/sys/freebsd/execinfo.d
@@ -25,7 +25,10 @@ extern (D) int backtrace(void** buffer, int size)
         asm nothrow @trusted { mov p[EBP], EBP; }
     else version (D_InlineAsm_X86_64)
         asm nothrow @trusted { mov p[RBP], RBP; }
-    else
+    else version (AArch64) {
+        import ldc.llvmasm;
+        __asm("str x29, $0", "=*m", &p);
+    } else
         static assert(false, "Architecture not supported.");
 
     int i;


### PR DESCRIPTION
I hope this is correct… This makes the 0.17 bootstrap compiler work, at least.