### PR TITLE
Fix profile timing measurements on AArch64.

### DIFF
--- a/src/rt/trace.d
+++ b/src/rt/trace.d
@@ -841,39 +841,64 @@ version (Windows)
 }
 else
 {
-    extern (D) void QueryPerformanceCounter(timer_t* ctr)
+    version (LDC)
     {
-        version (LDC)
+        version (AArch64)
         {
-            import ldc.intrinsics: llvm_readcyclecounter;
-            *ctr = llvm_readcyclecounter();
-        }
-        else version (D_InlineAsm_X86)
-        {
-            asm
+            import ldc.llvmasm: __asm;
+            // We cannot use ldc.intrinsics.llvm_readcyclecounter because that is not an accurate
+            // time counter (it is a counter of CPU cycles, where here we want a time clock).
+            // Also, priviledged execution rights are needed to enable correct counting with
+            // ldc.intrinsics.llvm_readcyclecounter on AArch64.
+            void QueryPerformanceCounter(timer_t* ctr)
             {
-                naked                   ;
-                mov       ECX,EAX       ;
-                rdtsc                   ;
-                mov   [ECX],EAX         ;
-                mov   4[ECX],EDX        ;
-                ret                     ;
+                *ctr = __asm!ulong("mrs $0, cntvct_el0", "=r");
             }
-        }
-        else version (D_InlineAsm_X86_64)
-        {
-            asm
+            void QueryPerformanceFrequency(timer_t* freq)
             {
-                naked                   ;
-                rdtsc                   ;
-                mov   [RDI],EAX         ;
-                mov   4[RDI],EDX        ;
-                ret                     ;
+                *freq = __asm!ulong("mrs $0, cntfrq_el0", "=r");
             }
         }
         else
         {
-            static assert(0);
+            void QueryPerformanceCounter(timer_t* ctr)
+            {
+                import ldc.intrinsics: llvm_readcyclecounter;
+                *ctr = llvm_readcyclecounter();
+            }
+        }
+    }
+    else
+    {
+        extern (D) void QueryPerformanceCounter(timer_t* ctr)
+        {
+            version (D_InlineAsm_X86)
+            {
+                asm
+                {
+                    naked                   ;
+                    mov       ECX,EAX       ;
+                    rdtsc                   ;
+                    mov   [ECX],EAX         ;
+                    mov   4[ECX],EDX        ;
+                    ret                     ;
+                }
+            }
+            else version (D_InlineAsm_X86_64)
+            {
+                asm
+                {
+                    naked                   ;
+                    rdtsc                   ;
+                    mov   [RDI],EAX         ;
+                    mov   4[RDI],EDX        ;
+                    ret                     ;
+                }
+            }
+            else
+            {
+                static assert(0);
+            }
         }
     }
 }

--- a/src/rt/trace.d
+++ b/src/rt/trace.d
@@ -850,18 +850,18 @@ else
             // time counter (it is a counter of CPU cycles, where here we want a time clock).
             // Also, priviledged execution rights are needed to enable correct counting with
             // ldc.intrinsics.llvm_readcyclecounter on AArch64.
-            void QueryPerformanceCounter(timer_t* ctr)
+            extern (D) void QueryPerformanceCounter(timer_t* ctr)
             {
                 *ctr = __asm!ulong("mrs $0, cntvct_el0", "=r");
             }
-            void QueryPerformanceFrequency(timer_t* freq)
+            extern (D) void QueryPerformanceFrequency(timer_t* freq)
             {
                 *freq = __asm!ulong("mrs $0, cntfrq_el0", "=r");
             }
         }
         else
         {
-            void QueryPerformanceCounter(timer_t* ctr)
+            extern (D) void QueryPerformanceCounter(timer_t* ctr)
             {
                 import ldc.intrinsics: llvm_readcyclecounter;
                 *ctr = llvm_readcyclecounter();


### PR DESCRIPTION
We cannot use ldc.intrinsics.llvm_readcyclecounter because that is not an accurate
time counter (it is a counter of CPU cycles, where here we want a time clock).
Also, priviledged execution rights are needed to enable correct counting with
ldc.intrinsics.llvm_readcyclecounter on AArch64.
So instead, we use the general virtual counter register, and also read out the frequency of that counter.

Tested on AWS EC2 Aarch64.
LDC PR: https://github.com/ldc-developers/ldc/pull/2950