### PR TITLE
Convert FreeBSD's sys/ttycom.h into core.sys.posix.sys.ttycom like MacOS X

### DIFF
--- a/changelog/freebsd-ttycom.dd
+++ b/changelog/freebsd-ttycom.dd
@@ -1,0 +1,15 @@
+Convert FreeBSD's sys/ttycom.h into core.sys.posix.sys.ttycom
+
+In FreeBSD, as in OSX, the tty part of ioctl is defined in
+sys/ttycom.h which is included by sys/ioctl.h.
+In druntime, there were OSX part of definitions in ttycom.d,
+but there were no FreeBSD equivalent.
+This change implements FreeBSD part of ttycom.d and ioccom.d,
+and public import core.sys.posix.sys.ttycom in ioctl.d.
+The OSX users and FreeBSD users can now use full ioctls related
+to tty by importing core.sys.posix.sys.ioctl, like including
+sys/ioctl.h in C language. (For example, TIOCGWINSZ ioctl was
+not provided in FreeBSD.)
+Since there are only version(OSX) and version(FreeBSD) part
+in ttycom.d, public import'ing core.sys.posix.sys.ttycom from
+ioctl.d will make no harm to other platforms.

--- a/src/core/sys/posix/sys/ioccom.d
+++ b/src/core/sys/posix/sys/ioccom.d
@@ -66,3 +66,64 @@ version (OSX)
         return _IOC!(T)(IOC_INOUT, cast(uint)g, cast(uint)n, T.sizeof);
     }
 }
+else version(FreeBSD)
+{
+    /* FreeBSD ioctl's encode the command in the lower 16-bits
+     * and the size of any in/out parameters in the lower 13 bits of the upper
+     * 16-bits of a 32 bit unsigned integer. The high 3 bits of the upper
+     * 16-bits encode the in/out status of the parameter.
+     */
+    enum uint IOCPARM_SHIFT = 13; // number of bits for ioctl size
+    enum uint IOCPARM_MASK = ((1 << IOCPARM_SHIFT) - 1); // parameter length mask
+    uint IOCPARM_LEN(uint x) // to extract the encoded parameter length
+    {
+        return ((x >> 16) & IOCPARM_MASK);
+    }
+    uint IOCBASECMD(uint x) // to extract the encoded command
+    {
+        return (x & ~(IOCPARM_MASK << 16));
+    }
+    uint IOCGROUP(uint x) // to extract the encoded group
+    {
+        return ((x >> 8) & 0xff);
+    }
+
+    enum uint IOCPARM_MAX = (1 << IOCPARM_SHIFT); // max size of ioctl args
+
+    enum uint IOC_VOID = 0x20000000; // no parameters
+    enum uint IOC_OUT = 0x40000000; // copy parameters back
+    enum uint IOC_IN = 0x80000000; // copy parameters into
+    enum uint IOC_INOUT = (IOC_IN | IOC_OUT);
+    enum uint IOC_DIRMASK = (IOC_VOID|IOC_OUT|IOC_IN);
+
+    // encode the ioctl info into 32 bits
+    uint _IOC(T=typeof(null))(uint inorout, uint group, uint num, size_t len)
+    {
+        return (inorout | ((len & IOCPARM_MASK) << 16) | (group << 8) | num);
+    }
+
+    // encode a command with no parameters
+    uint _IO(char g, int n)
+    {
+        return _IOC(IOC_VOID, cast(uint)g, cast(uint)n, cast(size_t)0);
+    }
+    uint _IOWINT(char g, int n)
+    {
+        return _IOC(IOC_VOID, cast(uint)g, cast(uint)n, int.sizeof);
+    }
+    // encode a command that returns info
+    uint _IOR(T)(char g, int n)
+    {
+        return _IOC!(T)(IOC_OUT, cast(uint)g, cast(uint)n, T.sizeof);
+    }
+    // encode a command that takes info
+    uint _IOW(T)(char g, int n)
+    {
+        return _IOC!(T)(IOC_IN, cast(uint)g, cast(uint)n, T.sizeof);
+    }
+    // encode a command that takes info and returns info
+    uint _IOWR(T)(char g, int n)
+    {
+        return _IOC!(T)(IOC_INOUT, cast(uint)g, cast(uint)n, T.sizeof);
+    }
+}

--- a/src/core/sys/posix/sys/ioccom.d
+++ b/src/core/sys/posix/sys/ioccom.d
@@ -107,7 +107,7 @@ else version(FreeBSD)
     {
         return _IOC(IOC_VOID, cast(uint)g, cast(uint)n, cast(size_t)0);
     }
-    uint _IOWINT(char g, int n)
+    uint _IOWINT(T=int)(char g, int n)
     {
         return _IOC(IOC_VOID, cast(uint)g, cast(uint)n, int.sizeof);
     }

--- a/src/core/sys/posix/sys/ioctl.d
+++ b/src/core/sys/posix/sys/ioctl.d
@@ -15,6 +15,7 @@
 module core.sys.posix.sys.ioctl;
 
 import core.stdc.config;
+public import core.sys.posix.sys.ttycom;
 
 version (OSX)
     version = Darwin;

--- a/src/core/sys/posix/sys/ioctl.d
+++ b/src/core/sys/posix/sys/ioctl.d
@@ -357,14 +357,6 @@ else version (FreeBSD)
         void* buf;
     }
 
-    struct winsize
-    {
-        ushort ws_row;
-        ushort ws_col;
-        ushort ws_xpixel;
-        ushort ws_ypixel;
-    }
-
     int ioctl(int, c_ulong, ...);
 }
 else version (NetBSD)

--- a/src/core/sys/posix/sys/ttycom.d
+++ b/src/core/sys/posix/sys/ttycom.d
@@ -110,6 +110,8 @@ version (OSX)
 }
 else version(FreeBSD)
 {
+    import std.conv;
+
     struct winsize {
         ushort  ws_row;     // rows, in characters
         ushort  ws_col;     // columns, in characters
@@ -154,20 +156,20 @@ else version(FreeBSD)
     					// 100 unused
     enum uint TIOCSTAT  = _IO('t', 101);       // simulate ^T status message
     enum uint TIOCUCNTL = _IOW!(int)('t', 102); // pty: set/clr usr cntl mode
-    enum uint   UIOCCMD(n) = _IO('u', n);      // usr cntl op "n"
+    enum uint   UIOCCMD(n) = _IO('u', n);       // usr cntl op "n"
     enum uint TIOCSWINSZ = _IOW!(winsize)('t', 103); // set window size
     enum uint TIOCGWINSZ = _IOR!(winsize)('t', 104); // get window size
     					// 105 unused
     enum uint TIOCMGET  = _IOR!(int)('t', 106); // get all modem bits
-    enum uint   TIOCM_LE  = 0001;               // line enable
-    enum uint   TIOCM_DTR = 0002;               // data terminal ready
-    enum uint   TIOCM_RTS = 0004;               // request to send
-    enum uint   TIOCM_ST  = 0010;               // secondary transmit
-    enum uint   TIOCM_SR  = 0020;               // secondary receive
-    enum uint   TIOCM_CTS = 0040;               // clear to send
-    enum uint   TIOCM_DCD = 0100;               // data carrier detect
-    enum uint   TIOCM_RI  = 0200;               // ring indicate
-    enum uint   TIOCM_DSR = 0400;               // data set ready
+    enum uint   TIOCM_LE  = 1;                  // line enable
+    enum uint   TIOCM_DTR = 2;                  // data terminal ready
+    enum uint   TIOCM_RTS = 4;                  // request to send
+    enum uint   TIOCM_ST  = octal!10;  // secondary transmit
+    enum uint   TIOCM_SR  = octal!20;  // secondary receive
+    enum uint   TIOCM_CTS = octal!40;  // clear to send
+    enum uint   TIOCM_DCD = octal!100; // data carrier detect
+    enum uint   TIOCM_RI  = octal!200; // ring indicate
+    enum uint   TIOCM_DSR = octal!400; // data set ready
     enum uint   TIOCM_CD  = TIOCM_DCD;
     enum uint   TIOCM_CAR = TIOCM_DCD;
     enum uint   TIOCM_RNG = TIOCM_RI;

--- a/src/core/sys/posix/sys/ttycom.d
+++ b/src/core/sys/posix/sys/ttycom.d
@@ -108,3 +108,99 @@ version (OSX)
     enum uint SLIPDISC = 4;       // serial IP discipline
     enum uint PPPDISC  = 5;       // PPP discipline
 }
+else version(FreeBSD)
+{
+    struct winsize {
+        ushort  ws_row;     // rows, in characters
+        ushort  ws_col;     // columns, in characters
+        ushort  ws_xpixel;  // horizontal size, pixels
+        ushort  ws_ypixel;  // vertical size, pixels
+    }
+
+    // Serial/TTY ioctl's
+    						// 0-2 compat
+    						// 3-7 unused
+    						// 8-10 compat
+    						// 11-12 unused
+    enum uint TIOCEXCL  = _IO('t', 13);        // set exclusive use of tty
+    enum uint TIOCNXCL  = _IO('t', 14);        // reset exclusive use of tty
+    enum uint TIOCGPTN  = _IOR!(int)('t', 15); // get pts number
+    enum uint TIOCFLUSH = _IOW!(int)('t', 16); // flush buffers
+                            // 17-18 compat
+    enum uint TIOCGETA  = _IOR!(termios)('t', 19); // get termios struct
+    enum uint TIOCSETA  = _IOW!(termios)('t', 20); // set termios struct
+    enum uint TIOCSETAW = _IOW!(termios)('t', 21); // drain output, set
+    enum uint TIOCSETAF = _IOW!(termios)('t', 22); // drn out, fls in, set
+    					// 23-25 unused
+    enum uint TIOCGETD  = _IOR!(int)('t', 26); // get line discipline
+    enum uint TIOCSETD  = _IOW!(int)('t', 27); // set line discipline
+    enum uint TIOCPTMASTER = _IO('t', 28);     // pts master validation
+					// 29-85 unused
+    enum uint TIOCGDRAINWAIT = _IOR!(int)('t', 86); // get ttywait timeout
+    enum uint TIOCSDRAINWAIT = _IOW!(int)('t', 87); // set ttywait timeout
+    					// 88 unused
+    					// 89-91 conflicts: tun and tap
+    enum uint TIOCTIMESTAMP = _IOR!(timeval)('t', 89); // enable/get timestamp of last input event
+    enum uint TIOCMGDTRWAIT = _IOR!(int)('t', 90); // modem: get wait on close
+    enum uint TIOCMSDTRWAIT = _IOW!(int)('t', 91); // modem: set wait on close
+    					// 92-93 tun and tap
+    					// 94-97 conflicts: tun and tap
+    enum uint TIOCDRAIN = _IO('t', 94); // wait till output drained
+    enum uint TIOCSIG   = _IOWINT!(int)('t', 95); // pty: generate signal
+    enum uint TIOCEXT   = _IOW!(int)('t', 96); // pty: external processing
+    enum uint TIOCSCTTY = _IO('t', 97);        // become controlling tty
+    enum uint TIOCCONS  = _IOW!(int)('t', 98); // become virtual console
+    enum uint TIOCGSID  = _IOR!(int)('t', 99); // get session id
+    					// 100 unused
+    enum uint TIOCSTAT  = _IO('t', 101);       // simulate ^T status message
+    enum uint TIOCUCNTL = _IOW!(int)('t', 102); // pty: set/clr usr cntl mode
+    enum uint   UIOCCMD(n) = _IO('u', n);      // usr cntl op "n"
+    enum uint TIOCSWINSZ = _IOW!(winsize)('t', 103); // set window size
+    enum uint TIOCGWINSZ = _IOR!(winsize)('t', 104); // get window size
+    					// 105 unused
+    enum uint TIOCMGET  = _IOR!(int)('t', 106); // get all modem bits
+    enum uint   TIOCM_LE  = 0001;               // line enable
+    enum uint   TIOCM_DTR = 0002;               // data terminal ready
+    enum uint   TIOCM_RTS = 0004;               // request to send
+    enum uint   TIOCM_ST  = 0010;               // secondary transmit
+    enum uint   TIOCM_SR  = 0020;               // secondary receive
+    enum uint   TIOCM_CTS = 0040;               // clear to send
+    enum uint   TIOCM_DCD = 0100;               // data carrier detect
+    enum uint   TIOCM_RI  = 0200;               // ring indicate
+    enum uint   TIOCM_DSR = 0400;               // data set ready
+    enum uint   TIOCM_CD  = TIOCM_DCD;
+    enum uint   TIOCM_CAR = TIOCM_DCD;
+    enum uint   TIOCM_RNG = TIOCM_RI;
+    enum uint TIOCMBIC  = _IOW!(int)('t', 107); // bic modem bits
+    enum uint TIOCMBIS  = _IOW!(int)('t', 108); // bis modem bits
+    enum uint TIOCMSET  = _IOW!(int)('t', 109); // set all modem bits
+    enum uint TIOCSTART = _IO('t', 110);        // start output like ^Q
+    enum uint TIOCSTOP  = _IO('t', 111);        // stop output like ^S
+    enum uint TIOCPKT   = _IOW!(int)('t', 112); // pty: set/clr packet mode
+    enum uint TIOCPKT_DATA       = 0x00;        // data packet
+    enum uint TIOCPKT_FLUSHREAD  = 0x01;        // flush packet
+    enum uint TIOCPKT_FLUSHWRITE = 0x02;        // flush packet
+    enum uint TIOCPKT_STOP       = 0x04;        // stop output
+    enum uint TIOCPKT_START      = 0x08;        // start output
+    enum uint TIOCPKT_NOSTOP     = 0x10;        // no more ^S, ^Q
+    enum uint TIOCPKT_DOSTOP     = 0x20;        // now do ^S, ^Q
+    enum uint TIOCPKT_IOCTL      = 0x40;        // state change of pty driver
+    enum uint TIOCNOTTY = _IO('t', 113);        // void tty association
+    enum uint TIOCSTI   = _IOW!(char)('t', 114); // simulate terminal input
+    enum uint TIOCOUTQ  = _IOR!(int)('t', 115); // output queue size
+    				// 116-117 compat
+    enum uint TIOCSPGRP = _IOW!(int)('t', 118); // set pgrp of tty
+    enum uint TIOCGPGRP = _IOR!(int)('t', 119); // get pgrp of tty
+
+    enum uint TIOCCDTR  = _IO('t', 120);       // clear data terminal ready
+    enum uint TIOCSDTR  = _IO('t', 121);       // set data terminal ready
+    enum uint TIOCCBRK  = _IO('t', 122);       // clear break bit
+    enum uint TIOCSBRK  = _IO('t', 123);       // set break bit
+                            // 124-127 compat
+
+    enum uint TTYDISC  = 0;       // termios tty line discipline
+    enum uint SLIPDISC = 4;       // serial IP discipline
+    enum uint PPPDISC  = 5;       // PPP discipline
+    enum uint NETGRAPHDISC = 6;   // Netgraph tty node discipline
+    enum uint H4DISC   = 7;       // Netgraph Blutooth H4 discipline
+}


### PR DESCRIPTION
In FreeBSD, as in OSX, the tty part of ioctl is defined in sys/ttycom.h which is included by sys/ioctl.h.
In druntime, there were OSX part of definitions in ttycom.d, but there were no FreeBSD equivalent.
This change implements FreeBSD part of ttycom.d and ioccom.d, and public import core.sys.posix.sys.ttycom in ioctl.d.
The OSX users and FreeBSD users can now use full ioctls related to tty by importing core.sys.posix.sys.ioctl, like including sys/ioctl.h in C language. (For example, TIOCGWINSZ ioctl was
not provided in FreeBSD.)
Since there are only version(OSX) and version(FreeBSD) part in ttycom.d, public import'ing  core.sys.posix.sys.ttycom from ioctl.d will make no harm to other platforms.
