### PR TITLE
[ltsmaster] Add setjmp/ucontext definitions for FreeBSD/aarch64

### DIFF
--- a/src/core/sys/posix/setjmp.d
+++ b/src/core/sys/posix/setjmp.d
@@ -163,6 +163,12 @@ else version( FreeBSD )
         enum _JBLEN = 5;
         struct _jmp_buf { c_long[_JBLEN + 1] _jb; }
     }
+    else version( AArch64 )
+    {
+        enum _JBLEN = 31;
+        // __int128_t
+        struct _jmp_buf { long[2][_JBLEN + 1] _jb; };
+    }
     else
         static assert(0);
     alias _jmp_buf[1] jmp_buf;
@@ -249,6 +255,11 @@ else version( FreeBSD )
         enum _JB_SIGMASK    = 3;
         enum _JB_SIGFLAG    = 5;
         struct _sigjmp_buf { c_long[_JBLEN + 1] _sjb; }
+    }
+    else version( AArch64 )
+    {
+        // __int128_t
+        struct _sigjmp_buf { long[2][_JBLEN + 1] _jb; };
     }
     else
         static assert(0);

--- a/src/core/sys/posix/ucontext.d
+++ b/src/core/sys/posix/ucontext.d
@@ -686,6 +686,38 @@ else version( FreeBSD )
             int[6]          mc_spare2;
         }
     }
+    else version( AArch64 )
+    {
+        alias __register_t = long;
+
+        struct gpregs
+        {
+            __register_t[30] gp_x;
+            __register_t     gp_lr;
+            __register_t     gp_sp;
+            __register_t     gp_elr;
+            uint             gp_spsr;
+            int              gp_pad;
+        }
+
+        struct fpregs
+        {
+            ulong[2][32]    fp_q; // __uint128_t
+            uint            fp_sr;
+            uint            fp_cr;
+            int             fp_flags;
+            int             fp_pad;
+        }
+
+        struct mcontext_t
+        {
+            gpregs          mc_gpregs;
+            fpregs          mc_fpregs;
+            int             mc_flags;
+            int             mc_pad;
+            ulong[8]        mc_spare;
+        }
+    }
 
     // <ucontext.h>
     enum UCF_SWAPPED = 0x00000001;


### PR DESCRIPTION
This is https://github.com/dlang/druntime/pull/2269 which is still not cherry-picked into ltsmaster