### PR TITLE
[ltsmaster] Allow support for PPC/PPC64 for FreeBSD

### DIFF
--- a/src/rt/sections_elf_shared.d
+++ b/src/rt/sections_elf_shared.d
@@ -16,8 +16,8 @@ else version (DragonFlyBSD) enum SharedELF = true;
 else enum SharedELF = false;
 static if (SharedELF):
 
-version (linux) version (PPC) version = (linux_PPC_Any);
-version (linux) version (PPC64) version = (linux_PPC_Any);
+version (linux) version (PPC) version = linux_PPC_Any;
+version (linux) version (PPC64) version = linux_PPC_Any;
 
 // debug = PRINTF;
 import core.memory;

--- a/src/rt/sections_elf_shared.d
+++ b/src/rt/sections_elf_shared.d
@@ -928,10 +928,10 @@ struct tls_index
 
 version(LDC)
 
+{
 version (linux) version (PPC) version = linux_PPC_Any;
 version (linux) version (PPC64) version = linux_PPC_Any;
 
-{
     version(linux_PPC_Any)
     {
         extern(C) void* __tls_get_addr_opt(tls_index* ti);

--- a/src/rt/sections_elf_shared.d
+++ b/src/rt/sections_elf_shared.d
@@ -16,9 +16,6 @@ else version (DragonFlyBSD) enum SharedELF = true;
 else enum SharedELF = false;
 static if (SharedELF):
 
-version (linux) version (PPC) version = linux_PPC_Any;
-version (linux) version (PPC64) version = linux_PPC_Any;
-
 // debug = PRINTF;
 import core.memory;
 import core.stdc.stdio;
@@ -930,6 +927,10 @@ struct tls_index
 }
 
 version(LDC)
+
+version (linux) version (PPC) version = linux_PPC_Any;
+version (linux) version (PPC64) version = linux_PPC_Any;
+
 {
     version(linux_PPC_Any)
     {

--- a/src/rt/sections_elf_shared.d
+++ b/src/rt/sections_elf_shared.d
@@ -16,6 +16,9 @@ else version (DragonFlyBSD) enum SharedELF = true;
 else enum SharedELF = false;
 static if (SharedELF):
 
+version (linux) version (PPC) version = (linux_PPC_Any);
+version (linux) version (PPC64) version = (linux_PPC_Any);
+
 // debug = PRINTF;
 import core.memory;
 import core.stdc.stdio;
@@ -928,12 +931,7 @@ struct tls_index
 
 version(LDC)
 {
-    version(PPC)
-    {
-        extern(C) void* __tls_get_addr_opt(tls_index* ti);
-        alias __tls_get_addr = __tls_get_addr_opt;
-    }
-    else version(PPC64)
+    version(linux_PPC_Any)
     {
         extern(C) void* __tls_get_addr_opt(tls_index* ti);
         alias __tls_get_addr = __tls_get_addr_opt;


### PR DESCRIPTION
FreeBSD uses __tls_get_addr, where Linux uses __tls_get_addr_opt on PowerPC architecture.