### PR TITLE
Try llvm_readcyclecounter for Rand48.defaultSeed on ARM, x86 linux, SPARC, RISC-V, non-OSX PPC

### DIFF
--- a/src/rt/util/random.d
+++ b/src/rt/util/random.d
@@ -55,6 +55,17 @@ struct Rand48
             rng_state = mach_absolute_time();
             popFront();
         }
+        else version (LDC)
+        {
+            import ldc.intrinsics : llvm_readcyclecounter;
+            import ctime = core.stdc.time : time;
+
+            rng_state = llvm_readcyclecounter();
+            if (rng_state != 0)
+                popFront();
+            else
+                seed((cast(uint) ctime.time(null)));
+        }
         else
         {
             // Fallback to libc timestamp in seconds.


### PR DESCRIPTION
RISC-V support for llvm_readcyclecounter was added in LLVM 9.