### PR TITLE
LDC: Switch from __asm to GCC-style asm syntax

### DIFF
--- a/src/core/cpuid.d
+++ b/src/core/cpuid.d
@@ -56,6 +56,9 @@
 
 module core.cpuid;
 
+version (GNU) version = GNU_OR_LDC;
+version (LDC) version = GNU_OR_LDC;
+
 @trusted:
 nothrow:
 @nogc:
@@ -426,7 +429,7 @@ CpuFeatures* getCpuFeatures() @nogc nothrow
     }
 
 
-version (GNU) {
+version (GNU_OR_LDC) {
     version (X86)
         enum supportedX86 = true;
     else version (X86_64)
@@ -509,18 +512,8 @@ void getcacheinfoCPUID2()
     // for old single-core CPUs.
     uint numinfos = 1;
     do {
-        version (GNU) asm pure nothrow @nogc {
+        version (GNU_OR_LDC) asm pure nothrow @nogc {
             "cpuid" : "=a" a[0], "=b" a[1], "=c" a[2], "=d" a[3] : "a" 2;
-        } else version (LDC) {
-            import ldc.llvmasm;
-            __asm(`mov $$2, %eax
-                   cpuid
-                   mov %eax, $0
-                   mov %ebx, 4$0
-                   mov %ecx, 8$0
-                   mov %edx, 12$0`,
-                "=*m,~{eax},~{ebx},~{ecx},~{edx}",
-                &a);
         } else asm pure nothrow @nogc {
             mov EAX, 2;
             cpuid;
@@ -563,7 +556,7 @@ void getcacheinfoCPUID4()
     int cachenum = 0;
     for (;;) {
         uint a, b, number_of_sets;
-        version (GNU) asm pure nothrow @nogc {
+        version (GNU_OR_LDC) asm pure nothrow @nogc {
             "cpuid" : "=a" a, "=b" b, "=c" number_of_sets : "a" 4, "c" cachenum : "edx";
         } else asm pure nothrow @nogc {
             mov EAX, 4;
@@ -603,7 +596,7 @@ void getcacheinfoCPUID4()
 void getAMDcacheinfo()
 {
     uint dummy, c5, c6, d6;
-    version (GNU) asm pure nothrow @nogc {
+    version (GNU_OR_LDC) asm pure nothrow @nogc {
         "cpuid" : "=a" dummy, "=c" c5 : "a" 0x8000_0005 : "ebx", "edx";
     } else asm pure nothrow @nogc {
         mov EAX, 0x8000_0005; // L1 cache
@@ -622,7 +615,7 @@ void getAMDcacheinfo()
         // AMD K6-III or K6-2+ or later.
         ubyte numcores = 1;
         if (max_extended_cpuid >= 0x8000_0008) {
-            version (GNU) asm pure nothrow @nogc {
+            version (GNU_OR_LDC) asm pure nothrow @nogc {
                 "cpuid" : "=a" dummy, "=c" numcores : "a" 0x8000_0008 : "ebx", "edx";
             } else asm pure nothrow @nogc {
                 mov EAX, 0x8000_0008;
@@ -633,7 +626,7 @@ void getAMDcacheinfo()
             if (numcores>cpuFeatures.maxCores) cpuFeatures.maxCores = numcores;
         }
 
-        version (GNU) asm pure nothrow @nogc {
+        version (GNU_OR_LDC) asm pure nothrow @nogc {
             "cpuid" : "=a" dummy, "=c" c6, "=d" d6 : "a" 0x8000_0006 : "ebx";
         } else asm pure nothrow @nogc {
             mov EAX, 0x8000_0006; // L2/L3 cache
@@ -662,7 +655,7 @@ void getCpuInfo0B()
     int threadsPerCore;
     uint a, b, c, d;
     do {
-        version (GNU) asm pure nothrow @nogc {
+        version (GNU_OR_LDC) asm pure nothrow @nogc {
             "cpuid" : "=a" a, "=b" b, "=c" c, "=d" d : "a" 0x0B, "c" level;
         } else asm pure nothrow @nogc {
             mov EAX, 0x0B;
@@ -694,7 +687,7 @@ void cpuidX86()
 
     uint a, b, c, d;
     uint* venptr = cast(uint*)cf.vendorID.ptr;
-    version (GNU)
+    version (GNU_OR_LDC)
     {
         asm pure nothrow @nogc { "cpuid" : "=a" max_cpuid, "=b" venptr[0], "=d" venptr[1], "=c" venptr[2] : "a" 0; }
         asm pure nothrow @nogc { "cpuid" : "=a" max_extended_cpuid : "a" 0x8000_0000 : "ebx", "ecx", "edx"; }
@@ -739,7 +732,7 @@ void cpuidX86()
     cf.probablyIntel = cf.vendorID == "GenuineIntel";
     cf.probablyAMD = (cf.vendorID == "AuthenticAMD" || cf.vendorID == "HygonGenuine");
     uint apic = 0; // brand index, apic id
-    version (GNU) asm pure nothrow @nogc {
+    version (GNU_OR_LDC) asm pure nothrow @nogc {
         "cpuid" : "=a" a, "=b" apic, "=c" cf.miscfeatures, "=d" cf.features : "a" 1;
     } else {
         asm pure nothrow @nogc {
@@ -762,7 +755,7 @@ void cpuidX86()
 
     if (max_cpuid >= 7)
     {
-        version (GNU) asm pure nothrow @nogc {
+        version (GNU_OR_LDC) asm pure nothrow @nogc {
             "cpuid" : "=a" a, "=b" cf.extfeatures, "=c" c : "a" 7, "c" 0 : "edx";
         } else {
             uint ext;
@@ -778,7 +771,7 @@ void cpuidX86()
 
     if (cf.miscfeatures & OSXSAVE_BIT)
     {
-        version (GNU) asm pure nothrow @nogc {
+        version (GNU_OR_LDC) asm pure nothrow @nogc {
             "xgetbv" : "=a" a, "=d" d : "c" 0;
         } else asm pure nothrow @nogc {
             mov ECX, 0;
@@ -792,7 +785,7 @@ void cpuidX86()
     cf.amdfeatures = 0;
     cf.amdmiscfeatures = 0;
     if (max_extended_cpuid >= 0x8000_0001) {
-        version (GNU) asm pure nothrow @nogc {
+        version (GNU_OR_LDC) asm pure nothrow @nogc {
             "cpuid" : "=a" a, "=c" cf.amdmiscfeatures, "=d" cf.amdfeatures : "a" 0x8000_0001 : "ebx";
         } else {
             asm pure nothrow @nogc {
@@ -813,7 +806,7 @@ void cpuidX86()
         cf.maxCores = 1;
         if (hyperThreadingBit) {
             // determine max number of cores for AMD
-            version (GNU) asm pure nothrow @nogc {
+            version (GNU_OR_LDC) asm pure nothrow @nogc {
                 "cpuid" : "=a" a, "=c" c : "a" 0x8000_0008 : "ebx", "edx";
             } else asm pure nothrow @nogc {
                 mov EAX, 0x8000_0008;
@@ -826,7 +819,7 @@ void cpuidX86()
 
     if (max_extended_cpuid >= 0x8000_0004) {
         uint* pnb = cast(uint*)cf.processorNameBuffer.ptr;
-        version (GNU)
+        version (GNU_OR_LDC)
         {
             asm pure nothrow @nogc { "cpuid" : "=a" pnb[0], "=b" pnb[1], "=c" pnb[ 2], "=d" pnb[ 3] : "a" 0x8000_0002; }
             asm pure nothrow @nogc { "cpuid" : "=a" pnb[4], "=b" pnb[5], "=c" pnb[ 6], "=d" pnb[ 7] : "a" 0x8000_0003; }
@@ -956,7 +949,7 @@ void cpuidX86()
         else cf.maxThreads = cf.maxCores;
 
         if (cf.probablyAMD && max_extended_cpuid >= 0x8000_001E) {
-            version (GNU) asm pure nothrow @nogc {
+            version (GNU_OR_LDC) asm pure nothrow @nogc {
                 "cpuid" : "=a" a, "=b" b : "a" 0x8000_001E : "ecx", "edx";
             } else {
                 asm pure nothrow @nogc {

--- a/src/core/math.d
+++ b/src/core/math.d
@@ -243,13 +243,17 @@ version (LDC)
             // y * log2(x)
             real yl2x(real x, real y)   @safe pure nothrow
             {
-                return __asm_trusted!real("fyl2x", "={st},{st(1)},{st},~{st(1)}", y, x);
+                real r;
+                asm @safe pure nothrow @nogc { "fyl2x" : "=st" (r) : "st" (x), "st(1)" (y) : "st(1)"; }
+                return r;
             }
 
             // y * log2(x + 1)
             real yl2xp1(real x, real y) @safe pure nothrow
             {
-                return __asm_trusted!real("fyl2xp1", "={st},{st(1)},{st},~{st(1)}", y, x);
+                real r;
+                asm @safe pure nothrow @nogc { "fyl2xp1" : "=st" (r) : "st" (x), "st(1)" (y) : "st(1)"; }
+                return r;
             }
         }
     }

--- a/src/core/sys/freebsd/execinfo.d
+++ b/src/core/sys/freebsd/execinfo.d
@@ -39,10 +39,7 @@ else
         else version (D_InlineAsm_X86_64)
             asm nothrow @trusted { mov p[RBP], RBP; }
         else version (AArch64) // LDC
-        {
-            import ldc.llvmasm;
-            __asm("str x29, $0", "=*m", &p);
-        }
+            asm nothrow @trusted { "str x29, %0" : "=m" (p); }
         else
             static assert(false, "Architecture not supported.");
 

--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -21,6 +21,15 @@ version (LDC)
     import ldc.llvmasm;
 
     version (Windows) version = LDC_Windows;
+
+    version (ARM)     version = ARM_Any;
+    version (AArch64) version = ARM_Any;
+
+    version (MIPS32) version = MIPS_Any;
+    version (MIPS64) version = MIPS_Any;
+
+    version (PPC)   version = PPC_Any;
+    version (PPC64) version = PPC_Any;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2608,64 +2617,29 @@ else
         }
         else version (LDC)
         {
-            version (PPC)
+            version (PPC_Any)
             {
                 // Nonvolatile registers, according to:
                 // System V Application Binary Interface
                 // PowerPC Processor Supplement, September 1995
-                size_t[18] regs = void;
-                __asm("std  14, $0", "=*m", regs.ptr +  0);
-                __asm("std  15, $0", "=*m", regs.ptr +  1);
-                __asm("std  16, $0", "=*m", regs.ptr +  2);
-                __asm("std  17, $0", "=*m", regs.ptr +  3);
-                __asm("std  18, $0", "=*m", regs.ptr +  4);
-                __asm("std  19, $0", "=*m", regs.ptr +  5);
-                __asm("std  20, $0", "=*m", regs.ptr +  6);
-                // Work around LLVM bug 21443 (http://llvm.org/bugs/show_bug.cgi?id=21443)
-                // Because we clobber r0 a different register is choosen
-                __asm("std  21, $0", "=*m,~{r0}", regs.ptr +  7);
-                __asm("std  22, $0", "=*m", regs.ptr +  8);
-                __asm("std  23, $0", "=*m", regs.ptr +  9);
-                __asm("std  24, $0", "=*m", regs.ptr + 10);
-                __asm("std  25, $0", "=*m", regs.ptr + 11);
-                __asm("std  26, $0", "=*m", regs.ptr + 12);
-                __asm("std  27, $0", "=*m", regs.ptr + 13);
-                __asm("std  28, $0", "=*m", regs.ptr + 14);
-                __asm("std  29, $0", "=*m", regs.ptr + 15);
-                __asm("std  30, $0", "=*m", regs.ptr + 16);
-                __asm("std  31, $0", "=*m", regs.ptr + 17);
-
-                __asm("std   1, $0", "=*m", &sp);
-            }
-            else version (PPC64)
-            {
-                // Nonvolatile registers, according to:
                 // ELFv1: 64-bit PowerPC ELF ABI Supplement 1.9, July 2004
                 // ELFv2: Power Architecture, 64-Bit ELV V2 ABI Specification,
                 //        OpenPOWER ABI for Linux Supplement, July 2014
                 size_t[18] regs = void;
-                __asm("std  14, $0", "=*m", regs.ptr +  0);
-                __asm("std  15, $0", "=*m", regs.ptr +  1);
-                __asm("std  16, $0", "=*m", regs.ptr +  2);
-                __asm("std  17, $0", "=*m", regs.ptr +  3);
-                __asm("std  18, $0", "=*m", regs.ptr +  4);
-                __asm("std  19, $0", "=*m", regs.ptr +  5);
-                __asm("std  20, $0", "=*m", regs.ptr +  6);
-                // Work around LLVM bug 21443 (http://llvm.org/bugs/show_bug.cgi?id=21443)
-                // Because we clobber r0 a different register is choosen
-                __asm("std  21, $0", "=*m,~{r0}", regs.ptr +  7);
-                __asm("std  22, $0", "=*m", regs.ptr +  8);
-                __asm("std  23, $0", "=*m", regs.ptr +  9);
-                __asm("std  24, $0", "=*m", regs.ptr + 10);
-                __asm("std  25, $0", "=*m", regs.ptr + 11);
-                __asm("std  26, $0", "=*m", regs.ptr + 12);
-                __asm("std  27, $0", "=*m", regs.ptr + 13);
-                __asm("std  28, $0", "=*m", regs.ptr + 14);
-                __asm("std  29, $0", "=*m", regs.ptr + 15);
-                __asm("std  30, $0", "=*m", regs.ptr + 16);
-                __asm("std  31, $0", "=*m", regs.ptr + 17);
+                static foreach (i; 0 .. regs.length)
+                {{
+                    enum int j = 14 + i; // source register
+                    static if (j == 21)
+                    {
+                        // Work around LLVM bug 21443 (http://llvm.org/bugs/show_bug.cgi?id=21443)
+                        // Because we clobber r0 a different register is chosen
+                        asm pure nothrow @nogc { ("std "~j.stringof~", %0") : "=m" (regs[i]) : : "r0"; }
+                    }
+                    else
+                        asm pure nothrow @nogc { ("std "~j.stringof~", %0") : "=m" (regs[i]); }
+                }}
 
-                __asm("std   1, $0", "=*m", &sp);
+                asm pure nothrow @nogc { "std 1, %0" : "=m" (sp); }
             }
             else version (AArch64)
             {
@@ -2673,56 +2647,47 @@ else
                 // 5.1.1.  Include x29 fp because it optionally can be a callee
                 // saved reg
                 size_t[11] regs = void;
-                __asm("stp x19, x20, $0", "=*m", regs.ptr + 0);
-                __asm("stp x21, x22, $0", "=*m", regs.ptr + 2);
-                __asm("stp x23, x24, $0", "=*m", regs.ptr + 4);
-                __asm("stp x25, x26, $0", "=*m", regs.ptr + 6);
-                __asm("stp x27, x28, $0", "=*m", regs.ptr + 8);
-                __asm("str x29, $0", "=*m", regs.ptr + 10);
-                sp = __asm!(void*)("mov $0, sp", "=r");
+                // store the registers in pairs
+                asm pure nothrow @nogc
+                {
+                    "stp x19, x20, %0" : "=m" (regs[ 0]), "=m" (regs[1]);
+                    "stp x21, x22, %0" : "=m" (regs[ 2]), "=m" (regs[3]);
+                    "stp x23, x24, %0" : "=m" (regs[ 4]), "=m" (regs[5]);
+                    "stp x25, x26, %0" : "=m" (regs[ 6]), "=m" (regs[7]);
+                    "stp x27, x28, %0" : "=m" (regs[ 8]), "=m" (regs[9]);
+                    "str x29, %0"      : "=m" (regs[10]);
+                    "mov %0, sp"       : "=r" (sp);
+                }
             }
             else version (ARM)
             {
                 // Callee-save registers, according to AAPCS, section 5.1.1.
                 // arm and thumb2 instructions
                 size_t[8] regs = void;
-                __asm("stm  $0, {r4-r11}", "r", regs.ptr);
-                sp = __asm!(void*)("mov $0, sp", "=r");
+                asm pure nothrow @nogc
+                {
+                    "stm %0, {r4-r11}" : : "r" (regs.ptr) : "memory";
+                    "mov %0, sp"       : "=r" (sp);
+                }
             }
-            else version (MIPS32)
+            else version (MIPS_Any)
             {
-                // Callee-save registers, according to MIPS Calling Convention
-                size_t[8] regs = void;
-                __asm(`.set  noat;
-                       sw $$16, 0($0);
-                       sw $$17, 4($0);
-                       sw $$18, 8($0);
-                       sw $$19, 12($0);
-                       sw $$20, 16($0);
-                       sw $$21, 20($0);
-                       sw $$22, 24($0);
-                       sw $$23, 28($0);
-                       .set  at;`, "r", regs.ptr);
-                __asm(".set  noat; sw $$29, 0($0); .set  at;", "r", &sp);
-            }
-            else version (MIPS64)
-            {
+                version (MIPS32)      enum store = "sw";
+                else version (MIPS64) enum store = "sd";
+                else static assert(0);
 
-                // Callee-save registers, according to MIPSpro N32 ABI Handbook,
-                // chapter 2, table 2-1.
+                // Callee-save registers, according to MIPS Calling Convention
+                // and MIPSpro N32 ABI Handbook, chapter 2, table 2-1.
                 // FIXME: Should $28 (gp) and $30 (s8) be saved, too?
                 size_t[8] regs = void;
-                __asm(`.set  noat;
-                       sd $$16,  0($0);
-                       sd $$17,  8($0);
-                       sd $$18, 16($0);
-                       sd $$19, 24($0);
-                       sd $$20, 32($0);
-                       sd $$21, 40($0);
-                       sd $$22, 48($0);
-                       sd $$23, 56($0);
-                       .set  at`, "r", regs.ptr);
-                __asm(".set  noat; sw $$29, 0($0); .set  at;", "r", &sp);
+                asm pure nothrow @nogc { ".set noat"; }
+                static foreach (i; 0 .. regs.length)
+                {{
+                    enum int j = 16 + i; // source register
+                    asm pure nothrow @nogc { (store ~ " $"~j.stringof~", %0") : "=m" (regs[i]); }
+                }}
+                asm pure nothrow @nogc { (store ~ " $29, %0") : "=m" (sp); }
+                asm pure nothrow @nogc { ".set at"; }
             }
             else
             {
@@ -3479,47 +3444,42 @@ extern (C) @nogc nothrow
 
 version (LDC)
 {
-    package(core.thread) void* getStackTop() nothrow @nogc @naked
+    version (X86)      version = LDC_stackTopAsm;
+    version (X86_64)   version = LDC_stackTopAsm;
+    version (ARM_Any)  version = LDC_stackTopAsm;
+    version (PPC_Any)  version = LDC_stackTopAsm;
+    version (MIPS_Any) version = LDC_stackTopAsm;
+
+    version (LDC_stackTopAsm)
     {
-        /* The inline assembler is written in a style that the code can be
-         * inlined.
-         * The use of intrinsic llvm_frameaddress is a reasonable default for
-         * cpu architectures without assembler support from LLVM. Because of
-         * the slightly different meaning the code must not be inlined.
+        /* The inline assembler is written in a style that the code can be inlined.
+         * If it isn't, the function is still naked, so the caller's stack pointer
+         * is used nevertheless.
          */
-        version (X86)
+        package(core.thread) void* getStackTop() nothrow @nogc @naked
         {
-            return __asm!(void*)("movl %esp, $0", "=r");
+            version (X86)
+                return __asm!(void*)("movl %esp, $0", "=r");
+            else version (X86_64)
+                return __asm!(void*)("movq %rsp, $0", "=r");
+            else version (ARM_Any)
+                return __asm!(void*)("mov $0, sp", "=r");
+            else version (PPC_Any)
+                return __asm!(void*)("mr $0, 1", "=r");
+            else version (MIPS_Any)
+                return __asm!(void*)("move $0, $$sp", "=r");
+            else
+                static assert(0);
         }
-        else version (X86_64)
-        {
-            return __asm!(void*)("movq %rsp, $0", "=r");
-        }
-        else version (AArch64)
-        {
-            return __asm!(void*)("mov $0, sp", "=r");
-        }
-        else version (ARM)
-        {
-            return __asm!(void*)("mov $0, sp", "=r");
-        }
-        else version (PPC)
-        {
-            return __asm!(void*)("mr $0, 1", "=r");
-        }
-        else version (PPC64)
-        {
-            return __asm!(void*)("mr $0, 1", "=r");
-        }
-        else version (MIPS32)
-        {
-            return __asm!(void*)(".set noat; move $0, $$sp; .set at", "=r");
-        }
-        else version (MIPS64)
-        {
-            return __asm!(void*)("move $0, $$sp", "=r");
-        }
-        else
+    }
+    else
+    {
+        /* The use of intrinsic llvm_frameaddress is a reasonable default for
+         * cpu architectures without assembler support from LLVM. Because of
+         * the slightly different meaning the function must neither be inlined
+         * nor naked.
+         */
+        package(core.thread) void* getStackTop() nothrow @nogc
         {
             import ldc.intrinsics;
             pragma(LDC_never_inline);

--- a/src/rt/trace.d
+++ b/src/rt/trace.d
@@ -847,18 +847,17 @@ else
     {
         version (AArch64)
         {
-            import ldc.llvmasm: __asm;
             // We cannot use ldc.intrinsics.llvm_readcyclecounter because that is not an accurate
             // time counter (it is a counter of CPU cycles, where here we want a time clock).
             // Also, priviledged execution rights are needed to enable correct counting with
             // ldc.intrinsics.llvm_readcyclecounter on AArch64.
             extern (D) void QueryPerformanceCounter(timer_t* ctr)
             {
-                *ctr = __asm!ulong("mrs $0, cntvct_el0", "=r");
+                asm { "mrs %0, cntvct_el0" : "=r" (*ctr); }
             }
             extern (D) void QueryPerformanceFrequency(timer_t* freq)
             {
-                *freq = __asm!ulong("mrs $0, cntfrq_el0", "=r");
+                asm { "mrs %0, cntfrq_el0" : "=r" (*freq); }
             }
         }
         else


### PR DESCRIPTION
`__asm` is still useful in a couple of places (e.g., one-liners), so I haven't replaced all occurrences.

`core.cpuid` now uses the existing assembly for GDC.