### PR TITLE
fix #3369: Memory leak when throwing exceptions in threads on windows

### DIFF
--- a/src/ldc/eh_msvc.d
+++ b/src/ldc/eh_msvc.d
@@ -255,6 +255,12 @@ Throwable chainExceptions(Throwable e, Throwable t)
 
 ExceptionStack exceptionStack;
 
+static ~this()
+{
+    // destructors not automatically run on globals
+    exceptionStack.destroy();
+}
+
 struct ExceptionStack
 {
 nothrow:


### PR DESCRIPTION
destructors have to be run explicitly on globals