### PR TITLE
Fix unguarded use of `assumeUsed`

### DIFF
--- a/src/core/thread/fiber.d
+++ b/src/core/thread/fiber.d
@@ -32,6 +32,8 @@ version (LDC)
         import ldc.sanitizers_optionally_linked;
     }
 }
+else
+    private enum assumeUsed = null;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Fiber Platform Detection


### PR DESCRIPTION
The import where `assumeUsed` is defined is guarded by `version (LDC)` but not the usage of the symbol.