### PR TITLE
arm_unwind.c: types definitions added

### DIFF
--- a/src/ldc/arm_unwind.c
+++ b/src/ldc/arm_unwind.c
@@ -18,6 +18,10 @@
 // clang's unwind.h doesn't have this
 typedef struct _Unwind_Context _Unwind_Context;
 
+// clang's unwind.h provides this
+typedef uintptr_t _Unwind_Ptr;
+typedef uintptr_t _Unwind_Word __attribute__((__mode__(__unwind_word__)));
+
 _Unwind_Ptr _d_eh_GetIP(_Unwind_Context *context)
 {
     return _Unwind_GetIP(context);


### PR DESCRIPTION
I compile it separately for "without default libs" targets

For some reason after updating clang-11 this is broke
