### PR TITLE
[WebAssembly] Add grow and size memory intrinsics

### DIFF
--- a/src/ldc/intrinsics.di
+++ b/src/ldc/intrinsics.di
@@ -679,3 +679,30 @@ static if (LLVM_atleast!6)
 pragma(LDC_intrinsic, "llvm.sideeffect")
     void llvm_sideeffect();
 }
+
+version(WebAssembly)
+{
+static if (LLVM_atleast!7)
+{
+/// Grows memory by a given delta and returns the previous size, or -1 if enough
+/// memory cannot be allocated.
+///
+/// Note:
+///     In the current version of WebAssembly, all memory instructions implicitly
+///     operate on memory index 0. This restriction may be lifted in future versions.
+///
+/// https://webassembly.github.io/spec/core/exec/instructions.html#exec-memory-grow
+pragma(LDC_intrinsic, "llvm.wasm.memory.grow.i32")
+    int llvm_wasm_memory_grow(int mem, int delta);
+
+/// Returns the current size of memory.
+///
+/// Note:
+///     In the current version of WebAssembly, all memory instructions implicitly
+///     operate on memory index 0. This restriction may be lifted in future versions.
+///
+/// https://webassembly.github.io/spec/core/exec/instructions.html#exec-memory-size
+pragma(LDC_intrinsic, "llvm.wasm.memory.size.i32")
+    int llvm_wasm_memory_size(int mem);
+}
+}


### PR DESCRIPTION
This patch adds new wasm-related memory intrinsics: llvm.wasm.memory.grow.i32 and llvm.wasm.memory.size.i32.

There's no LLVM Release Notes for these instructions, but added in https://github.com/llvm/llvm-project/commit/91ab25bbe3802c6c67060e3fc5065cb8b7147f0f