### PR TITLE
LDC: byteswap(ushort) fix

### DIFF
--- a/src/core/bitop.d
+++ b/src/core/bitop.d
@@ -622,6 +622,11 @@ struct BitRange
  * Returns:
  *      `x` with bytes swapped
  */
+version (LDC)
+{
+    alias byteswap = llvm_bswap!ushort;
+}
+else
 pragma(inline, false)
 ushort byteswap(ushort x) pure
 {


### PR DESCRIPTION
Default implementation works wrong for ARM Cortex M3 (32 bit).

This PR fixes it and maybe for other platforms too.
