### PR TITLE
Embedded ARM compilation fix

### DIFF
--- a/src/core/threadasm.S
+++ b/src/core/threadasm.S
@@ -595,7 +595,12 @@ CSYM(fiber_switchContext):
       sub sp, r1, #72
       vpop {d8-d15}
     #else
-      sub sp, r1, #8
+        #ifdef __ARM_EABI__
+            sub r1, #8
+            mov sp, r1
+        #else
+            sub sp, r1, #8
+        #endif
     #endif
 
     // we don't really care about r0, we only used that for padding.


### PR DESCRIPTION
`sub` instruction with set of registers `sp` and `r1` is not supported in EABI and causes translation error.
Present PR splits this instruction into two simplier.
