### PR TITLE
Add @nogc to core.sys.linux.execinfo

### DIFF
--- a/src/core/sys/linux/execinfo.d
+++ b/src/core/sys/linux/execinfo.d
@@ -11,6 +11,7 @@ version (linux):
 extern (C):
 nothrow:
 @system:
+@nogc:
 
 int backtrace(void** buffer, int size);
 char** backtrace_symbols(const(void*)* buffer, int size);


### PR DESCRIPTION
Make extern C functions in core.sys.linux.execinfo `@nogc`

Cherry pick e092594b9b776d48f4c54354f5c227e8e6ed8993 from dmd.