### PR TITLE
Add casWeak support

### DIFF
--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -1131,6 +1131,13 @@ version (CoreUnittest)
         }
     }
 
+    @betterC pure nothrow @nogc @safe unittest
+    {
+        int a;
+        if (casWeak!(MemoryOrder.acq_rel, MemoryOrder.raw)(&a, 0, 4))
+            assert(a == 4);
+    }
+
     @betterC pure nothrow unittest
     {
         // https://issues.dlang.org/show_bug.cgi?id=17821

--- a/src/core/internal/atomic.d
+++ b/src/core/internal/atomic.d
@@ -603,6 +603,8 @@ version (DigitalMars)
             static assert (false, "Unsupported architecture.");
     }
 
+    alias atomicCompareExchangeWeakNoResult = atomicCompareExchangeStrongNoResult;
+
     bool atomicCompareExchangeStrongNoResult(MemoryOrder succ = MemoryOrder.seq, MemoryOrder fail = MemoryOrder.seq, T)(T* dest, const T compare, T value) pure nothrow @nogc @trusted
         if (CanCAS!T)
     {
@@ -994,6 +996,12 @@ else version (GNU)
         if (CanCAS!T)
     {
         return atomicCompareExchangeImpl!(succ, fail, false)(dest, cast(T*)&compare, value);
+    }
+
+    bool atomicCompareExchangeWeakNoResult(MemoryOrder succ = MemoryOrder.seq, MemoryOrder fail = MemoryOrder.seq, T)(T* dest, const T compare, T value) pure nothrow @nogc @trusted
+        if (CanCAS!T)
+    {
+        return atomicCompareExchangeImpl!(succ, fail, true)(dest, cast(T*)&compare, value);
     }
 
     private bool atomicCompareExchangeImpl(MemoryOrder succ = MemoryOrder.seq, MemoryOrder fail = MemoryOrder.seq, bool weak, T)(T* dest, T* compare, T value) pure nothrow @nogc @trusted

--- a/src/core/internal/atomic.d
+++ b/src/core/internal/atomic.d
@@ -79,6 +79,10 @@ version (LDC)
     {
         return atomicCompareExchangeNoResult!(false, succ, fail, T)(dest, compare, value);
     }
+    bool atomicCompareExchangeWeakNoResult(MemoryOrder succ = MemoryOrder.seq, MemoryOrder fail = MemoryOrder.seq, T)(T* dest, const T compare, T value) pure nothrow @nogc @trusted
+    {
+        return atomicCompareExchangeNoResult!(true, succ, fail, T)(dest, compare, value);
+    }
 
     void atomicFence(MemoryOrder order = MemoryOrder.seq)() pure nothrow @nogc @trusted
     {


### PR DESCRIPTION
A missing function prevents use of casWeak. Cherry picked the added test from dlang/druntime.