### PR TITLE
Always inline `core.bitop.ror` and `rol`

### DIFF
--- a/src/core/bitop.d
+++ b/src/core/bitop.d
@@ -1180,6 +1180,7 @@ version (D_InlineAsm_X86_64)
  *  Bitwise rotate `value` left (`rol`) or right (`ror`) by
  *  `count` bit positions.
  */
+pragma(inline, true) // LDC
 pure T rol(T)(const T value, const uint count)
     if (__traits(isIntegral, T) && __traits(isUnsigned, T))
 {
@@ -1190,6 +1191,7 @@ pure T rol(T)(const T value, const uint count)
     return cast(T) ((value << count) | (value >> (T.sizeof * 8 - count)));
 }
 /// ditto
+pragma(inline, true) // LDC
 pure T ror(T)(const T value, const uint count)
     if (__traits(isIntegral, T) && __traits(isUnsigned, T))
 {
@@ -1200,6 +1202,7 @@ pure T ror(T)(const T value, const uint count)
     return cast(T) ((value >> count) | (value << (T.sizeof * 8 - count)));
 }
 /// ditto
+pragma(inline, true) // LDC
 pure T rol(uint count, T)(const T value)
     if (__traits(isIntegral, T) && __traits(isUnsigned, T))
 {
@@ -1210,6 +1213,7 @@ pure T rol(uint count, T)(const T value)
     return cast(T) ((value << count) | (value >> (T.sizeof * 8 - count)));
 }
 /// ditto
+pragma(inline, true) // LDC
 pure T ror(uint count, T)(const T value)
     if (__traits(isIntegral, T) && __traits(isUnsigned, T))
 {


### PR DESCRIPTION
This fixes a large performance regression of SHA by Phobos commit 6ca6549f9a6ed2622baf70bfa68d46d8bac58a40.  https://github.com/dlang/phobos/pull/7559