### PR TITLE
Fix teardown of DLLs with static druntime using the .exe GC

### DIFF
--- a/src/core/internal/gc/proxy.d
+++ b/src/core/internal/gc/proxy.d
@@ -298,4 +298,10 @@ extern (C)
             proxiedGC = null;
         }
     //}
+
+    version (LDC)
+    bool gc_isProxied() nothrow @nogc
+    {
+        return proxiedGC !is null;
+    }
 }

--- a/test/shared/Makefile
+++ b/test/shared/Makefile
@@ -37,7 +37,7 @@ $(ROOT)/loadDR.done $(ROOT)/host.done: RUN_ARGS:=$(DRUNTIMESO)
 else
 # Windows
 
-all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS))) loadlibwin dllrefcount dllgc
+all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS))) loadlibwin dllrefcount dllgc dll_gc_proxy_teardown
 LIB_EXT:=lib
 DLL_EXT:=dll
 CC:=cl.exe
@@ -47,21 +47,28 @@ $(ROOT)/loadDR.done $(ROOT)/host.done: RUN_ARGS:=$(subst .lib,.dll,$(DRUNTIMESO)
 dllrefcount:
 	$(DMD) $(DFLAGS) src/dllrefcount.d -of$(ROOT)/dllrefcount.exe
 	$(ROOT)/dllrefcount.exe
-	rm $(ROOT)/dllrefcount.*
 
 loadlibwin:
 	$(DMD) $(DFLAGS) src/loadlibwin.d -of$(ROOT)/loadlibwin.exe
 	$(ROOT)/loadlibwin.exe
-	rm $(ROOT)/loadlibwin.*
 
 dllgc:
 	$(DMD) $(DFLAGS) -version=DLL -shared -of$(ROOT)/dllgc.dll src/dllgc.d
 	$(DMD) $(DFLAGS) -of$(ROOT)/loaddllgc.exe src/dllgc.d
 	$(ROOT)/loaddllgc.exe
-	rm $(ROOT)/loaddllgc.* $(ROOT)/dllgc.*
 
 # LDC: this test is designed for .exe & .dll with separate druntimes
 dllgc: DFLAGS+=-link-defaultlib-shared=false
+
+# LDC addition: test teardown with separate druntimes, with the DLL using the .exe GC
+dll_gc_proxy_teardown: DFLAGS+=-link-defaultlib-shared=false
+dll_gc_proxy_teardown:
+	$(DMD) $(DFLAGS) -shared -L/EXPORT:gc_setProxy -L/EXPORT:gc_clrProxy -version=DLL -of$(ROOT)/dll_gc_proxy_teardown.dll src/dll_gc_proxy_teardown.d
+	$(DMD) $(DFLAGS) -shared -L/EXPORT:gc_setProxy -L/EXPORT:gc_clrProxy -version=DLL -version=NoUnload -of$(ROOT)/dll_gc_proxy_teardown_nounload.dll src/dll_gc_proxy_teardown.d
+	$(DMD) $(DFLAGS) -of$(ROOT)/load_dll_gc_proxy_teardown.exe src/dll_gc_proxy_teardown.d
+	$(DMD) $(DFLAGS) -version=NoUnload -of$(ROOT)/load_dll_gc_proxy_teardown_nounload.exe src/dll_gc_proxy_teardown.d
+	$(ROOT)/load_dll_gc_proxy_teardown.exe
+	$(ROOT)/load_dll_gc_proxy_teardown_nounload.exe
 
 # end Windows
 endif

--- a/test/shared/src/dll_gc_proxy_teardown.d
+++ b/test/shared/src/dll_gc_proxy_teardown.d
@@ -1,0 +1,57 @@
+version (DLL)
+{
+    import core.sys.windows.dll;
+    import core.sys.windows.windef : HINSTANCE;
+
+    // like SimpleDllMain mixin, except for DLL_PROCESS_DETACH
+    extern(Windows)
+    bool DllMain(HINSTANCE hInstance, uint ulReason, void* reserved)
+    {
+        import core.sys.windows.winnt;
+        switch (ulReason)
+        {
+            default: assert(0);
+
+            case DLL_PROCESS_ATTACH:
+                // initialize DLL druntime
+                return dll_process_attach(hInstance, true);
+
+            case DLL_PROCESS_DETACH:
+                version (NoUnload)
+                {
+                    // skip terminating the DLL druntime - the proxied GC has already been destroyed
+                }
+                else
+                {
+                    dll_process_detach(hInstance, true);
+                }
+                return true;
+
+            case DLL_THREAD_ATTACH:
+                return dll_thread_attach(true, true);
+
+            case DLL_THREAD_DETACH:
+                return dll_thread_detach(true, true);
+        }
+    }
+}
+else
+{
+    void main()
+    {
+        import core.runtime;
+
+        // dynamically load the DLL
+        version (NoUnload)
+            auto dll = Runtime.loadLibrary("dll_gc_proxy_teardown_nounload.dll");
+        else
+            auto dll = Runtime.loadLibrary("dll_gc_proxy_teardown.dll");
+
+        assert(dll);
+
+        version (NoUnload) {} else
+        Runtime.unloadLibrary(dll);
+
+        // .exe druntime is terminated right after this, before implicitly unloading the DLL for version(NoUnload)
+    }
+}


### PR DESCRIPTION
In case they aren't explicitly unloaded. This has worked before switching to `rt.sections_elf_shared` on Windows, simply because there was no druntime cleanup whatsoever.

Fix the segfault when trying to access the already destroyed .exe GC by skipping some cleanup steps.