### PR TITLE
AddressSanitizer fixes

### DIFF
--- a/src/core/internal/gc/bits.d
+++ b/src/core/internal/gc/bits.d
@@ -239,7 +239,9 @@ struct GCBits
             size_t cntWords = lastWord - firstWord;
             copyWordsShifted(firstWord, cntWords, firstOff, source);
 
-            wordtype src = (source[cntWords - 1] >> (BITS_PER_WORD - firstOff)) | (source[cntWords] << firstOff);
+            wordtype src = (source[cntWords - 1] >> (BITS_PER_WORD - firstOff));
+            if (lastOff >= firstOff) // prevent buffer overread
+                src |= (source[cntWords] << firstOff);
             wordtype mask = (BITS_2 << lastOff) - 1;
             data[lastWord] = (data[lastWord] & ~mask) | (src & mask);
         }

--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -1115,10 +1115,17 @@ void pureFree()(void* ptr) @system pure @nogc nothrow
 
     fakePureFree(y);
 
+  version (LDC_AddressSanitizer)
+  {
+    // Test must be disabled because ASan will report an error: requested allocation size 0xffffffffffffff00 (0x700 after adjustments for alignment, red zones etc.) exceeds maximum supported size of 0x10000000000
+  }
+  else
+  {
     // Workaround bug in glibc 2.26
     // See also: https://issues.dlang.org/show_bug.cgi?id=17956
     void* z = pureMalloc(size_t.max & ~255); // won't affect `errno`
     assert(errno == fakePureErrno()); // errno shouldn't change
+  }
   version (LDC)
   {
     // LLVM's 'Combine redundant instructions' optimization pass


### PR DESCRIPTION
Fix druntime overread bug, upstreamed: https://github.com/dlang/druntime/pull/3773
Mark ASan violating functions (correctly, scanning redzones for GC) with @noSanitize

With this PR, druntime unittests pass with ASan enabled.